### PR TITLE
Bump windows & fix wrong ntbcd link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["native", "windows", "ffi", "win32", "com"]
 categories = ["os::windows-apis", "api-bindings", "external-ffi-bindings"]
 
 [dependencies]
-windows = { version = "0.58.0", features = [
+windows = { version = "0.62.2", features = [
     "Win32_Foundation",
     "Win32_System_ApplicationInstallationAndServicing",
     "Win32_Devices_DeviceAndDriverInstallation",

--- a/src/ntbcd.rs
+++ b/src/ntbcd.rs
@@ -155,7 +155,7 @@ pub enum BCD_MESSAGE_TYPE {
 pub type BCD_MESSAGE_CALLBACK =
     std::option::Option<unsafe extern "system" fn(type_: BCD_MESSAGE_TYPE, Message: PWSTR)>;
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdSetLogging(
         BcdLoggingLevel: BCD_MESSAGE_TYPE,
@@ -163,27 +163,27 @@ extern "system" {
     ) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdInitializeBcdSyncMutant();
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdGetSystemStorePath(BcdSystemStorePath: *mut PWSTR) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdSetSystemStoreDevice(SystemPartition: UNICODE_STRING) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdOpenSystemStore(BcdStoreHandle: *mut HANDLE) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdOpenStoreFromFile(
         BcdFilePath: UNICODE_STRING,
@@ -191,17 +191,17 @@ extern "system" {
     ) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdCreateStore(BcdFilePath: UNICODE_STRING, BcdStoreHandle: *mut HANDLE) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdExportStore(BcdFilePath: UNICODE_STRING) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdExportStoreEx(
         BcdStoreHandle: HANDLE,
@@ -210,7 +210,7 @@ extern "system" {
     ) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdImportStore(BcdFilePath: UNICODE_STRING) -> NTSTATUS;
 }
@@ -222,7 +222,7 @@ pub enum BCD_IMPORT_FLAGS {
     BCD_IMPORT_DELETE_FIRMWARE_OBJECTS = 1,
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdImportStoreWithFlags(
         BcdFilePath: UNICODE_STRING,
@@ -230,12 +230,12 @@ extern "system" {
     ) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdDeleteObjectReferences(BcdStoreHandle: HANDLE, Identifier: *mut GUID) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdDeleteSystemStore() -> NTSTATUS;
 }
@@ -248,7 +248,7 @@ pub enum BCD_OPEN_FLAGS {
     BCD_OPEN_SYNC_FIRMWARE_ENTRIES = 2,
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdOpenStore(
         BcdFilePath: UNICODE_STRING,
@@ -257,22 +257,22 @@ extern "system" {
     ) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdCloseStore(BcdStoreHandle: HANDLE) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdFlushStore(BcdStoreHandle: HANDLE) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdForciblyUnloadStore(BcdStoreHandle: HANDLE) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdMarkAsSystemStore(BcdStoreHandle: HANDLE) -> NTSTATUS;
 }
@@ -740,7 +740,7 @@ impl std::fmt::Debug for BCD_OBJECT {
     }
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdEnumerateObjects(
         BcdStoreHandle: HANDLE,
@@ -751,7 +751,7 @@ extern "system" {
     ) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdOpenObject(
         BcdStoreHandle: HANDLE,
@@ -760,7 +760,7 @@ extern "system" {
     ) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdCreateObject(
         BcdStoreHandle: HANDLE,
@@ -770,12 +770,12 @@ extern "system" {
     ) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdDeleteObject(BcdObjectHandle: HANDLE) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdCloseObject(BcdObjectHandle: HANDLE) -> NTSTATUS;
 }
@@ -792,7 +792,7 @@ pub enum BCD_COPY_FLAGS {
     BCD_COPY_MIGRATE_ELEMENT_DATA = 32,
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdCopyObject(
         BcdStoreHandle: HANDLE,
@@ -803,7 +803,7 @@ extern "system" {
     ) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdCopyObjectEx(
         BcdStoreHandle: HANDLE,
@@ -815,7 +815,7 @@ extern "system" {
     ) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdCopyObjects(
         BcdStoreHandle: HANDLE,
@@ -825,7 +825,7 @@ extern "system" {
     ) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdMigrateObjectElementValues(
         TemplateObjectHandle: HANDLE,
@@ -834,7 +834,7 @@ extern "system" {
     ) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdQueryObject(
         BcdObjectHandle: HANDLE,
@@ -994,7 +994,7 @@ impl std::fmt::Debug for BCD_ELEMENT_DATATYPE {
     }
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdEnumerateElementTypes(
         BcdObjectHandle: HANDLE,
@@ -1378,7 +1378,7 @@ impl std::fmt::Debug for BCD_ELEMENT {
     }
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdEnumerateElements(
         BcdObjectHandle: HANDLE,
@@ -1402,7 +1402,7 @@ pub enum BCD_FLAGS {
     BCD_FLAG_DISABLE_POLICY_CHECKS = 128,
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdEnumerateElementsWithFlags(
         BcdObjectHandle: HANDLE,
@@ -1413,7 +1413,7 @@ extern "system" {
     ) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdEnumerateAndUnpackElements(
         BcdStoreHandle: HANDLE,
@@ -1425,7 +1425,7 @@ extern "system" {
     ) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdGetElementData(
         BcdObjectHandle: HANDLE,
@@ -1435,7 +1435,7 @@ extern "system" {
     ) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdGetElementDataWithFlags(
         BcdObjectHandle: HANDLE,
@@ -1446,7 +1446,7 @@ extern "system" {
     ) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdSetElementData(
         BcdObjectHandle: HANDLE,
@@ -1456,7 +1456,7 @@ extern "system" {
     ) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdSetElementDataWithFlags(
         BcdObjectHandle: HANDLE,
@@ -1467,7 +1467,7 @@ extern "system" {
     ) -> NTSTATUS;
 }
 
-#[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
+#[link(name = "bcd.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn BcdDeleteElement(BcdObjectHandle: HANDLE, BcdElement: u32) -> NTSTATUS;
 }

--- a/src/ntbcd.rs
+++ b/src/ntbcd.rs
@@ -1,6 +1,6 @@
 use windows::{
     core::{GUID, PWSTR},
-    Win32::Foundation::{BOOLEAN, HANDLE, NTSTATUS, UNICODE_STRING},
+    Win32::Foundation::{HANDLE, NTSTATUS, UNICODE_STRING},
 };
 
 use crate::bitfield::{BitfieldUnit, UnionField};
@@ -1326,7 +1326,7 @@ impl std::fmt::Debug for BCD_ELEMENT_INTEGER_LIST {
 
 #[repr(C)]
 pub struct BCD_ELEMENT_BOOLEAN {
-    pub Value: BOOLEAN,
+    pub Value: bool,
 }
 
 impl Default for BCD_ELEMENT_BOOLEAN {

--- a/src/ntdbg.rs
+++ b/src/ntdbg.rs
@@ -2,7 +2,7 @@ use windows::{
     core::GUID,
     Wdk::Foundation::OBJECT_ATTRIBUTES,
     Win32::{
-        Foundation::{BOOLEAN, HANDLE, NTSTATUS},
+        Foundation::{HANDLE, NTSTATUS},
         System::{
             Diagnostics::{
                 Debug::{DEBUG_EVENT, EXCEPTION_RECORD},
@@ -326,7 +326,7 @@ extern "system" {
 extern "system" {
     pub fn NtWaitForDebugEvent(
         DebugObjectHandle: HANDLE,
-        Alertable: BOOLEAN,
+        Alertable: bool,
         Timeout: *mut i64,
         WaitStateChange: *mut DBGUI_WAIT_STATE_CHANGE,
     ) -> NTSTATUS;

--- a/src/ntexapi.rs
+++ b/src/ntexapi.rs
@@ -11,7 +11,7 @@ use windows::{
         },
     },
     Win32::{
-        Foundation::{BOOLEAN, HANDLE, LUID, NTSTATUS, UNICODE_STRING},
+        Foundation::{HANDLE, LUID, NTSTATUS, UNICODE_STRING},
         Security::{GENERIC_MAPPING, SECURITY_DESCRIPTOR},
         System::{
             Diagnostics::Etw::PROFILE_SOURCE_INFO,
@@ -870,7 +870,7 @@ pub const FLG_USERMODE_VALID_BITS: u32 = 2989595123;
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn NtDelayExecution(Alertable: BOOLEAN, DelayInterval: *mut i64) -> NTSTATUS;
+    pub fn NtDelayExecution(Alertable: bool, DelayInterval: *mut i64) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -1242,7 +1242,7 @@ extern "system" {
         DesiredAccess: u32,
         ObjectAttributes: *mut OBJECT_ATTRIBUTES,
         EventType: EVENT_TYPE,
-        InitialState: BOOLEAN,
+        InitialState: bool,
     ) -> NTSTATUS;
 }
 
@@ -1349,8 +1349,8 @@ pub enum MUTANT_INFORMATION_CLASS {
 #[repr(C)]
 pub struct MUTANT_BASIC_INFORMATION {
     pub CurrentCount: i32,
-    pub OwnedByCaller: BOOLEAN,
-    pub AbandonedState: BOOLEAN,
+    pub OwnedByCaller: bool,
+    pub AbandonedState: bool,
 }
 
 impl Default for MUTANT_BASIC_INFORMATION {
@@ -1388,7 +1388,7 @@ extern "system" {
         MutantHandle: *mut HANDLE,
         DesiredAccess: u32,
         ObjectAttributes: *mut OBJECT_ATTRIBUTES,
-        InitialOwner: BOOLEAN,
+        InitialOwner: bool,
     ) -> NTSTATUS;
 }
 
@@ -1490,7 +1490,7 @@ pub enum TIMER_INFORMATION_CLASS {
 #[repr(C)]
 pub struct TIMER_BASIC_INFORMATION {
     pub RemainingTime: i64,
-    pub TimerState: BOOLEAN,
+    pub TimerState: bool,
 }
 
 impl Default for TIMER_BASIC_INFORMATION {
@@ -1531,9 +1531,9 @@ extern "system" {
         DueTime: *mut i64,
         TimerApcRoutine: PTIMER_APC_ROUTINE,
         TimerContext: *mut std::ffi::c_void,
-        ResumeTimer: BOOLEAN,
+        ResumeTimer: bool,
         Period: i32,
-        PreviousState: *mut BOOLEAN,
+        PreviousState: *mut bool,
     ) -> NTSTATUS;
 }
 
@@ -1549,7 +1549,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn NtCancelTimer(TimerHandle: HANDLE, CurrentState: *mut BOOLEAN) -> NTSTATUS;
+    pub fn NtCancelTimer(TimerHandle: HANDLE, CurrentState: *mut bool) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -1693,7 +1693,7 @@ extern "system" {
     pub fn NtReleaseKeyedEvent(
         KeyedEventHandle: HANDLE,
         KeyValue: *mut std::ffi::c_void,
-        Alertable: BOOLEAN,
+        Alertable: bool,
         Timeout: *mut i64,
     ) -> NTSTATUS;
 }
@@ -1703,7 +1703,7 @@ extern "system" {
     pub fn NtWaitForKeyedEvent(
         KeyedEventHandle: HANDLE,
         KeyValue: *mut std::ffi::c_void,
-        Alertable: BOOLEAN,
+        Alertable: bool,
         Timeout: *mut i64,
     ) -> NTSTATUS;
 }
@@ -1791,7 +1791,7 @@ extern "system" {
         StateName: *mut WNF_STATE_NAME,
         NameLifetime: WNF_STATE_NAME_LIFETIME,
         DataScope: WNF_DATA_SCOPE,
-        PersistData: BOOLEAN,
+        PersistData: bool,
         TypeId: *const WNF_TYPE_ID,
         MaximumStateSize: u32,
         SecurityDescriptor: *mut SECURITY_DESCRIPTOR,
@@ -1906,13 +1906,13 @@ pub struct WORKER_FACTORY_BASIC_INFORMATION {
     pub Timeout: i64,
     pub RetryTimeout: i64,
     pub IdleTimeout: i64,
-    pub Paused: BOOLEAN,
-    pub TimerSet: BOOLEAN,
-    pub QueuedToExWorker: BOOLEAN,
-    pub MayCreate: BOOLEAN,
-    pub CreateInProgress: BOOLEAN,
-    pub InsertedIntoQueue: BOOLEAN,
-    pub Shutdown: BOOLEAN,
+    pub Paused: bool,
+    pub TimerSet: bool,
+    pub QueuedToExWorker: bool,
+    pub MayCreate: bool,
+    pub CreateInProgress: bool,
+    pub InsertedIntoQueue: bool,
+    pub Shutdown: bool,
     pub BindingCount: u32,
     pub ThreadMinimum: u32,
     pub ThreadMaximum: u32,
@@ -2040,7 +2040,7 @@ extern "system" {
 extern "system" {
     pub fn NtSetTimerResolution(
         DesiredTime: u32,
-        SetResolution: BOOLEAN,
+        SetResolution: bool,
         ActualTime: *mut u32,
     ) -> NTSTATUS;
 }
@@ -2859,8 +2859,8 @@ pub struct SYSTEM_OBJECTTYPE_INFORMATION {
     pub GenericMapping: GENERIC_MAPPING,
     pub ValidAccessMask: u32,
     pub PoolType: u32,
-    pub SecurityRequired: BOOLEAN,
-    pub WaitableObject: BOOLEAN,
+    pub SecurityRequired: bool,
+    pub WaitableObject: bool,
     pub TypeName: UNICODE_STRING,
 }
 
@@ -3130,7 +3130,7 @@ impl std::fmt::Debug for SYSTEM_DPC_BEHAVIOR_INFORMATION {
 pub struct SYSTEM_QUERY_TIME_ADJUST_INFORMATION {
     pub TimeAdjustment: u32,
     pub TimeIncrement: u32,
-    pub Enable: BOOLEAN,
+    pub Enable: bool,
 }
 
 impl Default for SYSTEM_QUERY_TIME_ADJUST_INFORMATION {
@@ -3149,7 +3149,7 @@ impl std::fmt::Debug for SYSTEM_QUERY_TIME_ADJUST_INFORMATION {
 pub struct SYSTEM_QUERY_TIME_ADJUST_INFORMATION_PRECISE {
     pub TimeAdjustment: u64,
     pub TimeIncrement: u64,
-    pub Enable: BOOLEAN,
+    pub Enable: bool,
 }
 
 impl Default for SYSTEM_QUERY_TIME_ADJUST_INFORMATION_PRECISE {
@@ -3167,7 +3167,7 @@ impl std::fmt::Debug for SYSTEM_QUERY_TIME_ADJUST_INFORMATION_PRECISE {
 #[repr(C)]
 pub struct SYSTEM_SET_TIME_ADJUST_INFORMATION {
     pub TimeAdjustment: u32,
-    pub Enable: BOOLEAN,
+    pub Enable: bool,
 }
 
 impl Default for SYSTEM_SET_TIME_ADJUST_INFORMATION {
@@ -3185,7 +3185,7 @@ impl std::fmt::Debug for SYSTEM_SET_TIME_ADJUST_INFORMATION {
 #[repr(C)]
 pub struct SYSTEM_SET_TIME_ADJUST_INFORMATION_PRECISE {
     pub TimeAdjustment: u64,
-    pub Enable: BOOLEAN,
+    pub Enable: bool,
 }
 
 impl Default for SYSTEM_SET_TIME_ADJUST_INFORMATION_PRECISE {
@@ -3603,7 +3603,7 @@ impl std::fmt::Debug for EVENT_TRACE_PROFILE_LIST_INFORMATION {
 pub struct EVENT_TRACE_STACK_CACHING_INFORMATION {
     pub EventTraceInformationClass: EVENT_TRACE_INFORMATION_CLASS,
     pub TraceHandle: TRACEHANDLE,
-    pub Enabled: BOOLEAN,
+    pub Enabled: bool,
     pub Reserved: [u8; 3],
     pub CacheSize: u32,
     pub BucketCount: u32,
@@ -3629,7 +3629,7 @@ impl std::fmt::Debug for EVENT_TRACE_STACK_CACHING_INFORMATION {
 pub struct EVENT_TRACE_SOFT_RESTART_INFORMATION {
     pub EventTraceInformationClass: EVENT_TRACE_INFORMATION_CLASS,
     pub TraceHandle: TRACEHANDLE,
-    pub PersistTraceBuffers: BOOLEAN,
+    pub PersistTraceBuffers: bool,
     pub FileName: [u16; 1],
 }
 
@@ -3652,13 +3652,13 @@ impl std::fmt::Debug for EVENT_TRACE_SOFT_RESTART_INFORMATION {
 #[repr(C)]
 pub struct EVENT_TRACE_PROFILE_ADD_INFORMATION {
     pub EventTraceInformationClass: EVENT_TRACE_INFORMATION_CLASS,
-    pub PerfEvtEventSelect: BOOLEAN,
-    pub PerfEvtUnitSelect: BOOLEAN,
+    pub PerfEvtEventSelect: bool,
+    pub PerfEvtUnitSelect: bool,
     pub PerfEvtType: u32,
     pub CpuInfoHierarchy: [u32; 3],
     pub InitialInterval: u32,
-    pub AllowsHalt: BOOLEAN,
-    pub Persist: BOOLEAN,
+    pub AllowsHalt: bool,
+    pub Persist: bool,
     pub ProfileSourceDescription: [u16; 1],
 }
 
@@ -3769,8 +3769,8 @@ impl Default for SYSTEM_CRASH_DUMP_STATE_INFORMATION {
 
 #[repr(C)]
 pub struct SYSTEM_KERNEL_DEBUGGER_INFORMATION {
-    pub KernelDebuggerEnabled: BOOLEAN,
-    pub KernelDebuggerNotPresent: BOOLEAN,
+    pub KernelDebuggerEnabled: bool,
+    pub KernelDebuggerNotPresent: bool,
 }
 
 impl Default for SYSTEM_KERNEL_DEBUGGER_INFORMATION {
@@ -4287,8 +4287,8 @@ impl std::fmt::Debug for SYSTEM_BIGPOOL_INFORMATION {
 
 #[repr(C)]
 pub struct SYSTEM_POOL_ENTRY {
-    pub Allocated: BOOLEAN,
-    pub Spare0: BOOLEAN,
+    pub Allocated: bool,
+    pub Spare0: bool,
     pub AllocatorBackTraceIndex: u16,
     pub Size: u32,
     pub Anonymous1: SYSTEM_POOL_ENTRY_1,
@@ -4335,8 +4335,8 @@ pub struct SYSTEM_POOL_INFORMATION {
     pub TotalSize: usize,
     pub FirstEntry: *mut std::ffi::c_void,
     pub EntryOverhead: u16,
-    pub PoolTagPresent: BOOLEAN,
-    pub Spare0: BOOLEAN,
+    pub PoolTagPresent: bool,
+    pub Spare0: bool,
     pub NumberOfEntries: u32,
     pub Entries: [SYSTEM_POOL_ENTRY; 1],
 }
@@ -4420,7 +4420,7 @@ pub type PSYSTEM_WATCHDOG_HANDLER = std::option::Option<
         Action: WATCHDOG_HANDLER_ACTION,
         Context: *mut std::ffi::c_void,
         DataValue: *mut u32,
-        NoLocks: BOOLEAN,
+        NoLocks: bool,
     ) -> NTSTATUS,
 >;
 
@@ -4617,8 +4617,8 @@ impl std::fmt::Debug for SYSTEM_VERIFIER_CANCELLATION_INFORMATION {
 
 #[repr(C)]
 pub struct SYSTEM_REF_TRACE_INFORMATION {
-    pub TraceEnable: BOOLEAN,
-    pub TracePermanent: BOOLEAN,
+    pub TraceEnable: bool,
+    pub TracePermanent: bool,
     pub TraceProcessName: UNICODE_STRING,
     pub TracePoolTags: UNICODE_STRING,
 }
@@ -4673,10 +4673,10 @@ impl std::fmt::Debug for SYSTEM_PROCESS_ID_INFORMATION {
 
 #[repr(C)]
 pub struct SYSTEM_HYPERVISOR_QUERY_INFORMATION {
-    pub HypervisorConnected: BOOLEAN,
-    pub HypervisorDebuggingEnabled: BOOLEAN,
-    pub HypervisorPresent: BOOLEAN,
-    pub Spare0: [BOOLEAN; 5],
+    pub HypervisorConnected: bool,
+    pub HypervisorDebuggingEnabled: bool,
+    pub HypervisorPresent: bool,
+    pub Spare0: [bool; 5],
     pub EnabledEnlightenments: u64,
 }
 
@@ -7428,8 +7428,8 @@ pub struct SYSTEM_REGISTRY_APPEND_STRING_PARAMETERS {
     pub Type: u32,
     pub AppendBuffer: *mut u8,
     pub AppendBufferLength: u32,
-    pub CreateIfDoesntExist: BOOLEAN,
-    pub TruncateExistingValue: BOOLEAN,
+    pub CreateIfDoesntExist: bool,
+    pub TruncateExistingValue: bool,
 }
 
 impl Default for SYSTEM_REGISTRY_APPEND_STRING_PARAMETERS {
@@ -7446,7 +7446,7 @@ impl std::fmt::Debug for SYSTEM_REGISTRY_APPEND_STRING_PARAMETERS {
 
 #[repr(C)]
 pub struct SYSTEM_VHD_BOOT_INFORMATION {
-    pub OsDiskIsVhd: BOOLEAN,
+    pub OsDiskIsVhd: bool,
     pub OsVhdFilePathOffset: u32,
     pub OsVhdParentVolume: [u16; 1],
 }
@@ -8004,7 +8004,7 @@ impl std::fmt::Debug for PROCESSOR_PROFILE_CONTROL_AREA {
 #[repr(C)]
 pub struct SYSTEM_PROCESSOR_PROFILE_CONTROL_AREA {
     pub ProcessorProfileControlArea: PROCESSOR_PROFILE_CONTROL_AREA,
-    pub Allocate: BOOLEAN,
+    pub Allocate: bool,
 }
 
 impl Default for SYSTEM_PROCESSOR_PROFILE_CONTROL_AREA {
@@ -8443,8 +8443,8 @@ impl std::fmt::Debug for SYSTEM_PAGEFILE_INFORMATION_EX {
 
 #[repr(C)]
 pub struct SYSTEM_SECUREBOOT_INFORMATION {
-    pub SecureBootEnabled: BOOLEAN,
-    pub SecureBootCapable: BOOLEAN,
+    pub SecureBootEnabled: bool,
+    pub SecureBootCapable: bool,
 }
 
 impl Default for SYSTEM_SECUREBOOT_INFORMATION {
@@ -8979,7 +8979,7 @@ impl std::fmt::Debug for SYSTEM_PROCESS_INFORMATION_EXTENSION {
 
 #[repr(C)]
 pub struct SYSTEM_PORTABLE_WORKSPACE_EFI_LAUNCHER_INFORMATION {
-    pub EfiLauncherEnabled: BOOLEAN,
+    pub EfiLauncherEnabled: bool,
 }
 
 impl Default for SYSTEM_PORTABLE_WORKSPACE_EFI_LAUNCHER_INFORMATION {
@@ -8999,9 +8999,9 @@ impl std::fmt::Debug for SYSTEM_PORTABLE_WORKSPACE_EFI_LAUNCHER_INFORMATION {
 
 #[repr(C)]
 pub struct SYSTEM_KERNEL_DEBUGGER_INFORMATION_EX {
-    pub DebuggerAllowed: BOOLEAN,
-    pub DebuggerEnabled: BOOLEAN,
-    pub DebuggerPresent: BOOLEAN,
+    pub DebuggerAllowed: bool,
+    pub DebuggerEnabled: bool,
+    pub DebuggerPresent: bool,
 }
 
 impl Default for SYSTEM_KERNEL_DEBUGGER_INFORMATION_EX {
@@ -9132,7 +9132,7 @@ impl std::fmt::Debug for SYSTEM_MANUFACTURING_INFORMATION {
 
 #[repr(C)]
 pub struct SYSTEM_ENERGY_ESTIMATION_CONFIG_INFORMATION {
-    pub Enabled: BOOLEAN,
+    pub Enabled: bool,
 }
 
 impl Default for SYSTEM_ENERGY_ESTIMATION_CONFIG_INFORMATION {
@@ -9237,10 +9237,10 @@ impl std::fmt::Debug for SYSTEM_TPM_INFORMATION {
 
 #[repr(C)]
 pub struct SYSTEM_VSM_PROTECTION_INFORMATION {
-    pub DmaProtectionsAvailable: BOOLEAN,
-    pub DmaProtectionsInUse: BOOLEAN,
-    pub HardwareMbecAvailable: BOOLEAN,
-    pub ApicVirtualizationAvailable: BOOLEAN,
+    pub DmaProtectionsAvailable: bool,
+    pub DmaProtectionsInUse: bool,
+    pub HardwareMbecAvailable: bool,
+    pub ApicVirtualizationAvailable: bool,
 }
 
 impl Default for SYSTEM_VSM_PROTECTION_INFORMATION {
@@ -9257,7 +9257,7 @@ impl std::fmt::Debug for SYSTEM_VSM_PROTECTION_INFORMATION {
 
 #[repr(C)]
 pub struct SYSTEM_KERNEL_DEBUGGER_FLAGS {
-    pub KernelDebuggerIgnoreUmExceptions: BOOLEAN,
+    pub KernelDebuggerIgnoreUmExceptions: bool,
 }
 
 impl Default for SYSTEM_KERNEL_DEBUGGER_FLAGS {
@@ -9296,7 +9296,7 @@ impl std::fmt::Debug for SYSTEM_CODEINTEGRITYPOLICY_INFORMATION {
 pub struct SYSTEM_ISOLATED_USER_MODE_INFORMATION {
     _bitfield_align_1: [u8; 0],
     _bitfield_1: BitfieldUnit<[u8; 2]>,
-    pub Spare0: [BOOLEAN; 6],
+    pub Spare0: [bool; 6],
     pub Spare1: u64,
 }
 
@@ -9328,12 +9328,12 @@ impl std::fmt::Debug for SYSTEM_ISOLATED_USER_MODE_INFORMATION {
 
 impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
     #[inline]
-    pub fn SecureKernelRunning(&self) -> BOOLEAN {
+    pub fn SecureKernelRunning(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_SecureKernelRunning(&mut self, val: BOOLEAN) {
+    pub fn set_SecureKernelRunning(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -9342,12 +9342,12 @@ impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
     }
 
     #[inline]
-    pub fn HvciEnabled(&self) -> BOOLEAN {
+    pub fn HvciEnabled(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_HvciEnabled(&mut self, val: BOOLEAN) {
+    pub fn set_HvciEnabled(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -9356,12 +9356,12 @@ impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
     }
 
     #[inline]
-    pub fn HvciStrictMode(&self) -> BOOLEAN {
+    pub fn HvciStrictMode(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_HvciStrictMode(&mut self, val: BOOLEAN) {
+    pub fn set_HvciStrictMode(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -9370,12 +9370,12 @@ impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
     }
 
     #[inline]
-    pub fn DebugEnabled(&self) -> BOOLEAN {
+    pub fn DebugEnabled(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_DebugEnabled(&mut self, val: BOOLEAN) {
+    pub fn set_DebugEnabled(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -9384,12 +9384,12 @@ impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
     }
 
     #[inline]
-    pub fn FirmwarePageProtection(&self) -> BOOLEAN {
+    pub fn FirmwarePageProtection(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_FirmwarePageProtection(&mut self, val: BOOLEAN) {
+    pub fn set_FirmwarePageProtection(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -9398,12 +9398,12 @@ impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
     }
 
     #[inline]
-    pub fn EncryptionKeyAvailable(&self) -> BOOLEAN {
+    pub fn EncryptionKeyAvailable(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_EncryptionKeyAvailable(&mut self, val: BOOLEAN) {
+    pub fn set_EncryptionKeyAvailable(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -9412,12 +9412,12 @@ impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
     }
 
     #[inline]
-    pub fn SpareFlags(&self) -> BOOLEAN {
+    pub fn SpareFlags(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(6usize, 2u8) as u8) }
     }
 
     #[inline]
-    pub fn set_SpareFlags(&mut self, val: BOOLEAN) {
+    pub fn set_SpareFlags(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -9426,12 +9426,12 @@ impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
     }
 
     #[inline]
-    pub fn TrustletRunning(&self) -> BOOLEAN {
+    pub fn TrustletRunning(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(8usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_TrustletRunning(&mut self, val: BOOLEAN) {
+    pub fn set_TrustletRunning(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -9440,12 +9440,12 @@ impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
     }
 
     #[inline]
-    pub fn HvciDisableAllowed(&self) -> BOOLEAN {
+    pub fn HvciDisableAllowed(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(9usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_HvciDisableAllowed(&mut self, val: BOOLEAN) {
+    pub fn set_HvciDisableAllowed(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -9454,12 +9454,12 @@ impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
     }
 
     #[inline]
-    pub fn SpareFlags2(&self) -> BOOLEAN {
+    pub fn SpareFlags2(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(10usize, 6u8) as u8) }
     }
 
     #[inline]
-    pub fn set_SpareFlags2(&mut self, val: BOOLEAN) {
+    pub fn set_SpareFlags2(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -9469,16 +9469,16 @@ impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
 
     #[inline]
     pub fn new_bitfield_1(
-        SecureKernelRunning: BOOLEAN,
-        HvciEnabled: BOOLEAN,
-        HvciStrictMode: BOOLEAN,
-        DebugEnabled: BOOLEAN,
-        FirmwarePageProtection: BOOLEAN,
-        EncryptionKeyAvailable: BOOLEAN,
-        SpareFlags: BOOLEAN,
-        TrustletRunning: BOOLEAN,
-        HvciDisableAllowed: BOOLEAN,
-        SpareFlags2: BOOLEAN,
+        SecureKernelRunning: bool,
+        HvciEnabled: bool,
+        HvciStrictMode: bool,
+        DebugEnabled: bool,
+        FirmwarePageProtection: bool,
+        EncryptionKeyAvailable: bool,
+        SpareFlags: bool,
+        TrustletRunning: bool,
+        HvciDisableAllowed: bool,
+        SpareFlags2: bool,
     ) -> BitfieldUnit<[u8; 2]> {
         let mut bitfield_unit: BitfieldUnit<[u8; 2]> = Default::default();
 
@@ -11042,7 +11042,7 @@ impl std::fmt::Debug for SYSTEM_SPECULATION_CONTROL_INFORMATION {
 
 #[repr(C)]
 pub struct SYSTEM_DMA_GUARD_POLICY_INFORMATION {
-    pub DmaGuardPolicyEnabled: BOOLEAN,
+    pub DmaGuardPolicyEnabled: bool,
 }
 
 impl Default for SYSTEM_DMA_GUARD_POLICY_INFORMATION {
@@ -12350,7 +12350,7 @@ impl std::fmt::Debug for SYSTEM_ORIGINAL_IMAGE_FEATURE_INFORMATION_INPUT {
 #[repr(C)]
 pub struct SYSTEM_ORIGINAL_IMAGE_FEATURE_INFORMATION_OUTPUT {
     pub Version: u32,
-    pub FeatureIsEnabled: BOOLEAN,
+    pub FeatureIsEnabled: bool,
 }
 
 impl Default for SYSTEM_ORIGINAL_IMAGE_FEATURE_INFORMATION_OUTPUT {
@@ -13016,12 +13016,12 @@ pub enum ALTERNATIVE_ARCHITECTURE_TYPE {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn NtQueryDefaultLocale(UserProfile: BOOLEAN, DefaultLocaleId: *mut u32) -> NTSTATUS;
+    pub fn NtQueryDefaultLocale(UserProfile: bool, DefaultLocaleId: *mut u32) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn NtSetDefaultLocale(UserProfile: BOOLEAN, DefaultLocaleId: u32) -> NTSTATUS;
+    pub fn NtSetDefaultLocale(UserProfile: bool, DefaultLocaleId: u32) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]

--- a/src/ntexapi.rs
+++ b/src/ntexapi.rs
@@ -4208,8 +4208,6 @@ impl SYSTEM_BIGPOOL_ENTRY_1 {
     #[inline]
     pub fn set_NonPaged(&mut self, val: usize) {
         unsafe {
-            let val: u64 = std::mem::transmute(val);
-
             self._bitfield_1.as_mut().set(0usize, 1u8, val as u64)
         }
     }
@@ -4221,7 +4219,7 @@ impl SYSTEM_BIGPOOL_ENTRY_1 {
         bitfield_unit.set(0usize, 1u8, {
             let NonPaged: u64 = unsafe { std::mem::transmute(NonPaged) };
 
-            NonPaged as u64
+            NonPaged
         });
 
         bitfield_unit
@@ -4415,7 +4413,7 @@ pub enum WATCHDOG_HANDLER_ACTION {
     WdActionQueryState = 7,
 }
 
-pub type PSYSTEM_WATCHDOG_HANDLER = std::option::Option<
+pub type PSYSTEM_WATCHDOG_HANDLER = Option<
     unsafe extern "system" fn(
         Action: WATCHDOG_HANDLER_ACTION,
         Context: *mut std::ffi::c_void,
@@ -8083,8 +8081,8 @@ impl std::fmt::Debug for MEMORY_COMBINE_INFORMATION_EX2 {
 #[repr(C)]
 pub struct SYSTEM_ENTROPY_TIMING_INFORMATION {
     pub EntropyRoutine:
-        std::option::Option<unsafe extern "system" fn(arg1: *mut std::ffi::c_void, arg2: u32)>,
-    pub InitializationRoutine: std::option::Option<
+        Option<unsafe extern "system" fn(arg1: *mut std::ffi::c_void, arg2: u32)>,
+    pub InitializationRoutine: Option<
         unsafe extern "system" fn(
             arg1: *mut std::ffi::c_void,
             arg2: u32,
@@ -9334,11 +9332,7 @@ impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
 
     #[inline]
     pub fn set_SecureKernelRunning(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(0usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -9348,11 +9342,7 @@ impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
 
     #[inline]
     pub fn set_HvciEnabled(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(1usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(1usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -9362,11 +9352,7 @@ impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
 
     #[inline]
     pub fn set_HvciStrictMode(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(2usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(2usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -9376,11 +9362,7 @@ impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
 
     #[inline]
     pub fn set_DebugEnabled(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(3usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(3usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -9390,11 +9372,7 @@ impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
 
     #[inline]
     pub fn set_FirmwarePageProtection(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(4usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(4usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -9404,11 +9382,7 @@ impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
 
     #[inline]
     pub fn set_EncryptionKeyAvailable(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(5usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(5usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -9418,11 +9392,7 @@ impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
 
     #[inline]
     pub fn set_SpareFlags(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(6usize, 2u8, val as u64)
-        }
+        self._bitfield_1.set(6usize, 2u8, val as u64)
     }
 
     #[inline]
@@ -9432,11 +9402,7 @@ impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
 
     #[inline]
     pub fn set_TrustletRunning(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(8usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(8usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -9446,11 +9412,7 @@ impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
 
     #[inline]
     pub fn set_HvciDisableAllowed(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(9usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(9usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -9460,11 +9422,7 @@ impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
 
     #[inline]
     pub fn set_SpareFlags2(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(10usize, 6u8, val as u64)
-        }
+        self._bitfield_1.set(10usize, 6u8, val as u64)
     }
 
     #[inline]
@@ -9483,62 +9441,42 @@ impl SYSTEM_ISOLATED_USER_MODE_INFORMATION {
         let mut bitfield_unit: BitfieldUnit<[u8; 2]> = Default::default();
 
         bitfield_unit.set(0usize, 1u8, {
-            let SecureKernelRunning: u8 = unsafe { std::mem::transmute(SecureKernelRunning) };
-
             SecureKernelRunning as u64
         });
 
         bitfield_unit.set(1usize, 1u8, {
-            let HvciEnabled: u8 = unsafe { std::mem::transmute(HvciEnabled) };
-
             HvciEnabled as u64
         });
 
         bitfield_unit.set(2usize, 1u8, {
-            let HvciStrictMode: u8 = unsafe { std::mem::transmute(HvciStrictMode) };
-
             HvciStrictMode as u64
         });
 
         bitfield_unit.set(3usize, 1u8, {
-            let DebugEnabled: u8 = unsafe { std::mem::transmute(DebugEnabled) };
-
             DebugEnabled as u64
         });
 
         bitfield_unit.set(4usize, 1u8, {
-            let FirmwarePageProtection: u8 = unsafe { std::mem::transmute(FirmwarePageProtection) };
-
             FirmwarePageProtection as u64
         });
 
         bitfield_unit.set(5usize, 1u8, {
-            let EncryptionKeyAvailable: u8 = unsafe { std::mem::transmute(EncryptionKeyAvailable) };
-
             EncryptionKeyAvailable as u64
         });
 
         bitfield_unit.set(6usize, 2u8, {
-            let SpareFlags: u8 = unsafe { std::mem::transmute(SpareFlags) };
-
             SpareFlags as u64
         });
 
         bitfield_unit.set(8usize, 1u8, {
-            let TrustletRunning: u8 = unsafe { std::mem::transmute(TrustletRunning) };
-
             TrustletRunning as u64
         });
 
         bitfield_unit.set(9usize, 1u8, {
-            let HvciDisableAllowed: u8 = unsafe { std::mem::transmute(HvciDisableAllowed) };
-
             HvciDisableAllowed as u64
         });
 
         bitfield_unit.set(10usize, 6u8, {
-            let SpareFlags2: u8 = unsafe { std::mem::transmute(SpareFlags2) };
-
             SpareFlags2 as u64
         });
 

--- a/src/ntioapi.rs
+++ b/src/ntioapi.rs
@@ -227,30 +227,22 @@ impl std::fmt::Debug for FILE_INTERNAL_INFORMATION_1_1 {
 impl FILE_INTERNAL_INFORMATION_1_1 {
     #[inline]
     pub fn MftRecordIndex(&self) -> i64 {
-        unsafe { std::mem::transmute(self._bitfield_1.get(0usize, 48u8)) }
+        u64::cast_signed(self._bitfield_1.get(0usize, 48u8))
     }
 
     #[inline]
     pub fn set_MftRecordIndex(&mut self, val: i64) {
-        unsafe {
-            let val: u64 = std::mem::transmute(val);
-
-            self._bitfield_1.set(0usize, 48u8, val as u64)
-        }
+        self._bitfield_1.set(0usize, 48u8, val as u64)
     }
 
     #[inline]
     pub fn SequenceNumber(&self) -> i64 {
-        unsafe { std::mem::transmute(self._bitfield_1.get(48usize, 16u8)) }
+        u64::cast_signed(self._bitfield_1.get(48usize, 16u8))
     }
 
     #[inline]
     pub fn set_SequenceNumber(&mut self, val: i64) {
-        unsafe {
-            let val: u64 = std::mem::transmute(val);
-
-            self._bitfield_1.set(48usize, 16u8, val as u64)
-        }
+        self._bitfield_1.set(48usize, 16u8, val as u64)
     }
 
     #[inline]
@@ -258,14 +250,10 @@ impl FILE_INTERNAL_INFORMATION_1_1 {
         let mut bitfield_unit: BitfieldUnit<[u8; 8]> = Default::default();
 
         bitfield_unit.set(0usize, 48u8, {
-            let MftRecordIndex: u64 = unsafe { std::mem::transmute(MftRecordIndex) };
-
             MftRecordIndex as u64
         });
 
         bitfield_unit.set(48usize, 16u8, {
-            let SequenceNumber: u64 = unsafe { std::mem::transmute(SequenceNumber) };
-
             SequenceNumber as u64
         });
 

--- a/src/ntioapi.rs
+++ b/src/ntioapi.rs
@@ -7,7 +7,7 @@ use windows::{
         },
     },
     Win32::{
-        Foundation::{BOOLEAN, HANDLE, NTSTATUS, UNICODE_STRING},
+        Foundation::{HANDLE, NTSTATUS, UNICODE_STRING},
         Security::SID,
         Storage::FileSystem::FILE_SEGMENT_ELEMENT,
         System::IO::{IO_STATUS_BLOCK, PIO_APC_ROUTINE},
@@ -497,11 +497,11 @@ extern "system" {
         IoStatusBlock: *mut IO_STATUS_BLOCK,
         Buffer: *mut std::ffi::c_void,
         Length: u32,
-        ReturnSingleEntry: BOOLEAN,
+        ReturnSingleEntry: bool,
         EaList: *mut std::ffi::c_void,
         EaListLength: u32,
         EaIndex: *mut u32,
-        RestartScan: BOOLEAN,
+        RestartScan: bool,
     ) -> NTSTATUS;
 }
 
@@ -586,7 +586,7 @@ extern "system" {
         Buffer: *mut std::ffi::c_void,
         Length: u32,
         CompletionFilter: u32,
-        WatchTree: BOOLEAN,
+        WatchTree: bool,
     ) -> NTSTATUS;
 }
 
@@ -601,7 +601,7 @@ extern "system" {
         Buffer: *mut std::ffi::c_void,
         Length: u32,
         CompletionFilter: u32,
-        WatchTree: BOOLEAN,
+        WatchTree: bool,
         DirectoryNotifyInformationClass: DIRECTORY_NOTIFY_INFORMATION_CLASS,
     ) -> NTSTATUS;
 }
@@ -711,7 +711,7 @@ extern "system" {
         Count: u32,
         NumEntriesRemoved: *mut u32,
         Timeout: *mut i64,
-        Alertable: BOOLEAN,
+        Alertable: bool,
     ) -> NTSTATUS;
 }
 
@@ -734,7 +734,7 @@ extern "system" {
         ApcContext: *mut std::ffi::c_void,
         IoStatus: NTSTATUS,
         IoStatusInformation: usize,
-        AlreadySignaled: *mut BOOLEAN,
+        AlreadySignaled: *mut bool,
     ) -> NTSTATUS;
 }
 
@@ -742,7 +742,7 @@ extern "system" {
 extern "system" {
     pub fn NtCancelWaitCompletionPacket(
         WaitCompletionPacketHandle: HANDLE,
-        RemoveSignaledPacket: BOOLEAN,
+        RemoveSignaledPacket: bool,
     ) -> NTSTATUS;
 }
 
@@ -880,7 +880,7 @@ impl std::fmt::Debug for MOUNTMGR_DRIVE_LETTER_TARGET {
 
 #[repr(C)]
 pub struct MOUNTMGR_DRIVE_LETTER_INFORMATION {
-    pub DriveLetterWasAssigned: BOOLEAN,
+    pub DriveLetterWasAssigned: bool,
     pub CurrentDriveLetter: u8,
 }
 

--- a/src/ntkeapi.rs
+++ b/src/ntkeapi.rs
@@ -1,4 +1,4 @@
-use windows::Win32::Foundation::{BOOLEAN, NTSTATUS};
+use windows::Win32::Foundation::{NTSTATUS};
 
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -54,7 +54,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn NtSetDebugFilterState(ComponentId: u32, Level: u32, State: BOOLEAN) -> NTSTATUS;
+    pub fn NtSetDebugFilterState(ComponentId: u32, Level: u32, State: bool) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]

--- a/src/ntldr.rs
+++ b/src/ntldr.rs
@@ -2,7 +2,7 @@ use windows::{
     core::{PCWSTR, PSTR, PWSTR},
     Wdk::Foundation::OBJECT_ATTRIBUTES,
     Win32::{
-        Foundation::{BOOLEAN, HANDLE, NTSTATUS, UNICODE_STRING},
+        Foundation::{HANDLE, NTSTATUS, UNICODE_STRING},
         System::{
             Kernel::{LIST_ENTRY, RTL_BALANCED_NODE, SINGLE_LIST_ENTRY, STRING},
             SystemServices::{
@@ -73,7 +73,7 @@ pub type PLDR_INIT_ROUTINE = std::option::Option<
         DllHandle: *mut std::ffi::c_void,
         Reason: u32,
         Context: *mut std::ffi::c_void,
-    ) -> BOOLEAN,
+    ) -> bool,
 >;
 
 #[repr(C)]
@@ -879,7 +879,7 @@ extern "system" {
 extern "system" {
     pub fn LdrGetKnownDllSectionHandle(
         DllName: PCWSTR,
-        KnownDlls32: BOOLEAN,
+        KnownDlls32: bool,
         Section: *mut HANDLE,
     ) -> NTSTATUS;
 }
@@ -960,7 +960,7 @@ extern "system" {
         BaseAddress: *mut std::ffi::c_void,
         NumberOfBytes: usize,
         FileLength: u32,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 pub type PLDR_IMPORT_MODULE_CALLBACK = std::option::Option<
@@ -1528,7 +1528,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn LdrUnloadAlternateResourceModule(DllHandle: *mut std::ffi::c_void) -> BOOLEAN;
+    pub fn LdrUnloadAlternateResourceModule(DllHandle: *mut std::ffi::c_void) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -1536,7 +1536,7 @@ extern "system" {
     pub fn LdrUnloadAlternateResourceModuleEx(
         DllHandle: *mut std::ffi::c_void,
         Flags: u32,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[repr(C)]
@@ -1625,14 +1625,14 @@ pub type PLDR_ENUM_CALLBACK = std::option::Option<
     unsafe extern "system" fn(
         ModuleInformation: *mut LDR_DATA_TABLE_ENTRY,
         Parameter: *mut std::ffi::c_void,
-        Stop: *mut BOOLEAN,
+        Stop: *mut bool,
     ),
 >;
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn LdrEnumerateLoadedModules(
-        ReservedFlag: BOOLEAN,
+        ReservedFlag: bool,
         EnumProc: PLDR_ENUM_CALLBACK,
         Context: *mut std::ffi::c_void,
     ) -> NTSTATUS;
@@ -1642,7 +1642,7 @@ extern "system" {
 extern "system" {
     pub fn LdrOpenImageFileOptionsKey(
         SubKey: *mut UNICODE_STRING,
-        Wow64: BOOLEAN,
+        Wow64: bool,
         NewKeyHandle: *mut HANDLE,
     ) -> NTSTATUS;
 }
@@ -1680,7 +1680,7 @@ extern "system" {
         Buffer: *mut std::ffi::c_void,
         BufferSize: u32,
         ReturnedLength: *mut u32,
-        Wow64: BOOLEAN,
+        Wow64: bool,
     ) -> NTSTATUS;
 }
 
@@ -1754,12 +1754,12 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn LdrControlFlowGuardEnforced() -> BOOLEAN;
+    pub fn LdrControlFlowGuardEnforced() -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn LdrIsModuleSxsRedirected(DllHandle: *mut std::ffi::c_void) -> BOOLEAN;
+    pub fn LdrIsModuleSxsRedirected(DllHandle: *mut std::ffi::c_void) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]

--- a/src/ntlpcapi.rs
+++ b/src/ntlpcapi.rs
@@ -1,7 +1,7 @@
 use windows::{
     Wdk::Foundation::OBJECT_ATTRIBUTES,
     Win32::{
-        Foundation::{BOOLEAN, HANDLE, NTSTATUS, UNICODE_STRING},
+        Foundation::{HANDLE, NTSTATUS, UNICODE_STRING},
         Security::{PSID, SECURITY_DESCRIPTOR, SECURITY_QUALITY_OF_SERVICE},
         System::{Threading::SRWLOCK, WindowsProgramming::CLIENT_ID},
     },
@@ -573,7 +573,7 @@ extern "system" {
         PortHandle: *mut HANDLE,
         PortContext: *mut std::ffi::c_void,
         ConnectionRequest: *mut PORT_MESSAGE,
-        AcceptConnection: BOOLEAN,
+        AcceptConnection: bool,
         ServerView: *mut PORT_VIEW,
         ClientView: *mut REMOTE_PORT_VIEW,
     ) -> NTSTATUS;
@@ -1076,7 +1076,7 @@ impl std::fmt::Debug for ALPC_SERVER_INFORMATION_1_1 {
 
 #[repr(C)]
 pub struct ALPC_SERVER_INFORMATION_1_2 {
-    pub ThreadBlocked: BOOLEAN,
+    pub ThreadBlocked: bool,
     pub ConnectedProcessId: HANDLE,
     pub ConnectionPortName: UNICODE_STRING,
 }
@@ -1403,7 +1403,7 @@ extern "system" {
         PortContext: *mut std::ffi::c_void,
         ConnectionRequest: *mut PORT_MESSAGE,
         ConnectionMessageAttributes: *mut ALPC_MESSAGE_ATTRIBUTES,
-        AcceptConnection: BOOLEAN,
+        AcceptConnection: bool,
     ) -> NTSTATUS;
 }
 
@@ -1532,14 +1532,14 @@ extern "system" {
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn AlpcRegisterCompletionListWorkerThread(CompletionList: *mut std::ffi::c_void)
-    -> BOOLEAN;
+    -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn AlpcUnregisterCompletionListWorkerThread(
         CompletionList: *mut std::ffi::c_void,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]

--- a/src/ntmmapi.rs
+++ b/src/ntmmapi.rs
@@ -1,7 +1,7 @@
 use windows::{
     Wdk::{Foundation::OBJECT_ATTRIBUTES, System::Memory::SECTION_INHERIT},
     Win32::{
-        Foundation::{BOOLEAN, HANDLE, NTSTATUS, UNICODE_STRING},
+        Foundation::{HANDLE, NTSTATUS, UNICODE_STRING},
         System::{
             Memory::{CFG_CALL_TARGET_INFO, MEM_EXTENDED_PARAMETER},
             IO::IO_STATUS_BLOCK,
@@ -2131,7 +2131,7 @@ pub struct SECTION_IMAGE_INFORMATION {
     pub ImageCharacteristics: u16,
     pub DllCharacteristics: u16,
     pub Machine: u16,
-    pub ImageContainsCode: BOOLEAN,
+    pub ImageContainsCode: bool,
     pub Anonymous3: SECTION_IMAGE_INFORMATION_3,
     pub LoaderFlags: u32,
     pub ImageFileSize: u32,
@@ -3171,7 +3171,7 @@ extern "system" {
 extern "system" {
     pub fn NtTerminateEnclave(
         BaseAddress: *mut std::ffi::c_void,
-        WaitForThread: BOOLEAN,
+        WaitForThread: bool,
     ) -> NTSTATUS;
 }
 
@@ -3180,7 +3180,7 @@ extern "system" {
     pub fn NtCallEnclave(
         Routine: PENCLAVE_ROUTINE,
         Parameter: *mut std::ffi::c_void,
-        WaitForThread: BOOLEAN,
+        WaitForThread: bool,
         ReturnValue: *mut *mut std::ffi::c_void,
     ) -> NTSTATUS;
 }

--- a/src/ntnls.rs
+++ b/src/ntnls.rs
@@ -1,5 +1,3 @@
-use windows::Win32::Foundation::BOOLEAN;
-
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
 
@@ -9,11 +7,11 @@ extern "system" {
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
 
-    pub static mut NlsMbCodePageTag: BOOLEAN;
+    pub static mut NlsMbCodePageTag: bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
 
-    pub static mut NlsMbOemCodePageTag: BOOLEAN;
+    pub static mut NlsMbOemCodePageTag: bool;
 }

--- a/src/ntobapi.rs
+++ b/src/ntobapi.rs
@@ -1,7 +1,7 @@
 use windows::{
     Wdk::Foundation::{OBJECT_ATTRIBUTES, OBJECT_INFORMATION_CLASS},
     Win32::{
-        Foundation::{BOOLEAN, HANDLE, NTSTATUS, UNICODE_STRING},
+        Foundation::{HANDLE, NTSTATUS, UNICODE_STRING},
         Security::GENERIC_MAPPING,
         System::Kernel::WAIT_TYPE,
     },
@@ -71,8 +71,8 @@ pub struct OBJECT_TYPE_INFORMATION {
     pub InvalidAttributes: u32,
     pub GenericMapping: GENERIC_MAPPING,
     pub ValidAccessMask: u32,
-    pub SecurityRequired: BOOLEAN,
-    pub MaintainHandleCount: BOOLEAN,
+    pub SecurityRequired: bool,
+    pub MaintainHandleCount: bool,
     pub TypeIndex: u8,
     pub ReservedByte: i8,
     pub PoolType: u32,
@@ -111,8 +111,8 @@ impl std::fmt::Debug for OBJECT_TYPES_INFORMATION {
 
 #[repr(C)]
 pub struct OBJECT_HANDLE_FLAG_INFORMATION {
-    pub Inherit: BOOLEAN,
-    pub ProtectFromClose: BOOLEAN,
+    pub Inherit: bool,
+    pub ProtectFromClose: bool,
 }
 
 impl Default for OBJECT_HANDLE_FLAG_INFORMATION {
@@ -165,7 +165,7 @@ extern "system" {
     pub fn NtSignalAndWaitForSingleObject(
         SignalHandle: HANDLE,
         WaitHandle: HANDLE,
-        Alertable: BOOLEAN,
+        Alertable: bool,
         Timeout: *mut i64,
     ) -> NTSTATUS;
 }
@@ -176,7 +176,7 @@ extern "system" {
         Count: u32,
         Handles: *mut HANDLE,
         WaitType: WAIT_TYPE,
-        Alertable: BOOLEAN,
+        Alertable: bool,
         Timeout: *mut i64,
     ) -> NTSTATUS;
 }
@@ -187,7 +187,7 @@ extern "system" {
         Count: u32,
         Handles: *mut i32,
         WaitType: WAIT_TYPE,
-        Alertable: BOOLEAN,
+        Alertable: bool,
         Timeout: *mut i64,
     ) -> NTSTATUS;
 }
@@ -250,8 +250,8 @@ extern "system" {
         DirectoryHandle: HANDLE,
         Buffer: *mut std::ffi::c_void,
         Length: u32,
-        ReturnSingleEntry: BOOLEAN,
-        RestartScan: BOOLEAN,
+        ReturnSingleEntry: bool,
+        RestartScan: bool,
         Context: *mut u32,
         ReturnLength: *mut u32,
     ) -> NTSTATUS;

--- a/src/ntpebteb.rs
+++ b/src/ntpebteb.rs
@@ -1,7 +1,7 @@
 use windows::{
     core::{GUID, PSTR},
     Win32::{
-        Foundation::{BOOLEAN, HANDLE, NTSTATUS, UNICODE_STRING},
+        Foundation::{HANDLE, NTSTATUS, UNICODE_STRING},
         System::{
             Kernel::{LIST_ENTRY, NT_TIB, PROCESSOR_NUMBER, SLIST_HEADER},
             Threading::CRITICAL_SECTION,
@@ -105,9 +105,9 @@ impl std::fmt::Debug for API_SET_VALUE_ENTRY {
 
 #[repr(C)]
 pub struct PEB {
-    pub InheritedAddressSpace: BOOLEAN,
-    pub ReadImageFileExecOptions: BOOLEAN,
-    pub BeingDebugged: BOOLEAN,
+    pub InheritedAddressSpace: bool,
+    pub ReadImageFileExecOptions: bool,
+    pub BeingDebugged: bool,
     pub Anonymous1: PEB_1,
     pub Mutant: HANDLE,
     pub ImageBaseAddress: *mut std::ffi::c_void,
@@ -201,7 +201,7 @@ pub struct PEB {
 
 #[repr(C)]
 pub struct PEB_1 {
-    pub BitField: UnionField<BOOLEAN>,
+    pub BitField: UnionField<bool>,
     pub Anonymous1: UnionField<PEB_1_1>,
     pub union_field: u8,
 }
@@ -237,12 +237,12 @@ impl std::fmt::Debug for PEB_1_1 {
 
 impl PEB_1_1 {
     #[inline]
-    pub fn ImageUsesLargePages(&self) -> BOOLEAN {
+    pub fn ImageUsesLargePages(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_ImageUsesLargePages(&mut self, val: BOOLEAN) {
+    pub fn set_ImageUsesLargePages(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -251,12 +251,12 @@ impl PEB_1_1 {
     }
 
     #[inline]
-    pub fn IsProtectedProcess(&self) -> BOOLEAN {
+    pub fn IsProtectedProcess(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_IsProtectedProcess(&mut self, val: BOOLEAN) {
+    pub fn set_IsProtectedProcess(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -265,12 +265,12 @@ impl PEB_1_1 {
     }
 
     #[inline]
-    pub fn IsImageDynamicallyRelocated(&self) -> BOOLEAN {
+    pub fn IsImageDynamicallyRelocated(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_IsImageDynamicallyRelocated(&mut self, val: BOOLEAN) {
+    pub fn set_IsImageDynamicallyRelocated(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -279,12 +279,12 @@ impl PEB_1_1 {
     }
 
     #[inline]
-    pub fn SkipPatchingUser32Forwarders(&self) -> BOOLEAN {
+    pub fn SkipPatchingUser32Forwarders(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_SkipPatchingUser32Forwarders(&mut self, val: BOOLEAN) {
+    pub fn set_SkipPatchingUser32Forwarders(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -293,12 +293,12 @@ impl PEB_1_1 {
     }
 
     #[inline]
-    pub fn IsPackagedProcess(&self) -> BOOLEAN {
+    pub fn IsPackagedProcess(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_IsPackagedProcess(&mut self, val: BOOLEAN) {
+    pub fn set_IsPackagedProcess(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -307,12 +307,12 @@ impl PEB_1_1 {
     }
 
     #[inline]
-    pub fn IsAppContainer(&self) -> BOOLEAN {
+    pub fn IsAppContainer(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_IsAppContainer(&mut self, val: BOOLEAN) {
+    pub fn set_IsAppContainer(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -321,12 +321,12 @@ impl PEB_1_1 {
     }
 
     #[inline]
-    pub fn IsProtectedProcessLight(&self) -> BOOLEAN {
+    pub fn IsProtectedProcessLight(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(6usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_IsProtectedProcessLight(&mut self, val: BOOLEAN) {
+    pub fn set_IsProtectedProcessLight(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -335,12 +335,12 @@ impl PEB_1_1 {
     }
 
     #[inline]
-    pub fn IsLongPathAwareProcess(&self) -> BOOLEAN {
+    pub fn IsLongPathAwareProcess(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_IsLongPathAwareProcess(&mut self, val: BOOLEAN) {
+    pub fn set_IsLongPathAwareProcess(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -350,14 +350,14 @@ impl PEB_1_1 {
 
     #[inline]
     pub fn new_bitfield_1(
-        ImageUsesLargePages: BOOLEAN,
-        IsProtectedProcess: BOOLEAN,
-        IsImageDynamicallyRelocated: BOOLEAN,
-        SkipPatchingUser32Forwarders: BOOLEAN,
-        IsPackagedProcess: BOOLEAN,
-        IsAppContainer: BOOLEAN,
-        IsProtectedProcessLight: BOOLEAN,
-        IsLongPathAwareProcess: BOOLEAN,
+        ImageUsesLargePages: bool,
+        IsProtectedProcess: bool,
+        IsImageDynamicallyRelocated: bool,
+        SkipPatchingUser32Forwarders: bool,
+        IsPackagedProcess: bool,
+        IsAppContainer: bool,
+        IsProtectedProcessLight: bool,
+        IsLongPathAwareProcess: bool,
     ) -> BitfieldUnit<[u8; 1]> {
         let mut bitfield_unit: BitfieldUnit<[u8; 1]> = Default::default();
 
@@ -940,7 +940,7 @@ pub struct TEB {
     pub ReservedForDebuggerInstrumentation: [*mut std::ffi::c_void; 16],
     pub SystemReserved1: [*mut std::ffi::c_void; 30],
     pub PlaceholderCompatibilityMode: i8,
-    pub PlaceholderHydrationAlwaysExplicit: BOOLEAN,
+    pub PlaceholderHydrationAlwaysExplicit: bool,
     pub PlaceholderReserved: [i8; 10],
     pub ProxiedProcessId: u32,
     pub ActivationStack: ACTIVATION_CONTEXT_STACK,
@@ -951,8 +951,8 @@ pub struct TEB {
     pub InstrumentationCallbackPreviousPc: usize,
     pub InstrumentationCallbackPreviousSp: usize,
     pub TxFsContext: u32,
-    pub InstrumentationCallbackDisabled: BOOLEAN,
-    pub UnalignedLoadStoreExceptions: BOOLEAN,
+    pub InstrumentationCallbackDisabled: bool,
+    pub UnalignedLoadStoreExceptions: bool,
     pub GdiTebBatch: GDI_TEB_BATCH,
     pub RealClientId: CLIENT_ID,
     pub GdiCachedProcessHandle: HANDLE,

--- a/src/ntpebteb.rs
+++ b/src/ntpebteb.rs
@@ -243,11 +243,7 @@ impl PEB_1_1 {
 
     #[inline]
     pub fn set_ImageUsesLargePages(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(0usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -257,11 +253,7 @@ impl PEB_1_1 {
 
     #[inline]
     pub fn set_IsProtectedProcess(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(1usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(1usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -271,11 +263,7 @@ impl PEB_1_1 {
 
     #[inline]
     pub fn set_IsImageDynamicallyRelocated(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(2usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(2usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -285,11 +273,7 @@ impl PEB_1_1 {
 
     #[inline]
     pub fn set_SkipPatchingUser32Forwarders(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(3usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(3usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -299,11 +283,7 @@ impl PEB_1_1 {
 
     #[inline]
     pub fn set_IsPackagedProcess(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(4usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(4usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -313,11 +293,7 @@ impl PEB_1_1 {
 
     #[inline]
     pub fn set_IsAppContainer(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(5usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(5usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -327,11 +303,7 @@ impl PEB_1_1 {
 
     #[inline]
     pub fn set_IsProtectedProcessLight(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(6usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(6usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -341,11 +313,7 @@ impl PEB_1_1 {
 
     #[inline]
     pub fn set_IsLongPathAwareProcess(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(7usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(7usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -362,53 +330,34 @@ impl PEB_1_1 {
         let mut bitfield_unit: BitfieldUnit<[u8; 1]> = Default::default();
 
         bitfield_unit.set(0usize, 1u8, {
-            let ImageUsesLargePages: u8 = unsafe { std::mem::transmute(ImageUsesLargePages) };
-
             ImageUsesLargePages as u64
         });
 
         bitfield_unit.set(1usize, 1u8, {
-            let IsProtectedProcess: u8 = unsafe { std::mem::transmute(IsProtectedProcess) };
-
             IsProtectedProcess as u64
         });
 
         bitfield_unit.set(2usize, 1u8, {
-            let IsImageDynamicallyRelocated: u8 =
-                unsafe { std::mem::transmute(IsImageDynamicallyRelocated) };
-
             IsImageDynamicallyRelocated as u64
         });
 
         bitfield_unit.set(3usize, 1u8, {
-            let SkipPatchingUser32Forwarders: u8 =
-                unsafe { std::mem::transmute(SkipPatchingUser32Forwarders) };
-
             SkipPatchingUser32Forwarders as u64
         });
 
         bitfield_unit.set(4usize, 1u8, {
-            let IsPackagedProcess: u8 = unsafe { std::mem::transmute(IsPackagedProcess) };
-
             IsPackagedProcess as u64
         });
 
         bitfield_unit.set(5usize, 1u8, {
-            let IsAppContainer: u8 = unsafe { std::mem::transmute(IsAppContainer) };
-
             IsAppContainer as u64
         });
 
         bitfield_unit.set(6usize, 1u8, {
-            let IsProtectedProcessLight: u8 =
-                unsafe { std::mem::transmute(IsProtectedProcessLight) };
-
             IsProtectedProcessLight as u64
         });
 
         bitfield_unit.set(7usize, 1u8, {
-            let IsLongPathAwareProcess: u8 = unsafe { std::mem::transmute(IsLongPathAwareProcess) };
-
             IsLongPathAwareProcess as u64
         });
 

--- a/src/ntpoapi.rs
+++ b/src/ntpoapi.rs
@@ -1,5 +1,5 @@
 use windows::Win32::{
-    Foundation::{BOOLEAN, HANDLE, NTSTATUS},
+    Foundation::{HANDLE, NTSTATUS},
     System::{
         Kernel::PROCESSOR_NUMBER,
         Power::{
@@ -59,7 +59,7 @@ pub enum POWER_REQUEST_TYPE_INTERNAL {
 pub struct POWER_REQUEST_ACTION {
     pub PowerRequestHandle: HANDLE,
     pub RequestType: POWER_REQUEST_TYPE_INTERNAL,
-    pub SetAction: BOOLEAN,
+    pub SetAction: bool,
     pub ProcessHandle: HANDLE,
 }
 
@@ -888,7 +888,7 @@ pub type PENTER_STATE_HANDLER = std::option::Option<
 #[repr(C)]
 pub struct POWER_STATE_HANDLER {
     pub Type: POWER_STATE_HANDLER_TYPE,
-    pub RtcWake: BOOLEAN,
+    pub RtcWake: bool,
     pub Spare: [u8; 3],
     pub Handler: PENTER_STATE_HANDLER,
     pub Context: *mut std::ffi::c_void,
@@ -914,7 +914,7 @@ pub type PENTER_STATE_NOTIFY_HANDLER = std::option::Option<
     unsafe extern "system" fn(
         State: POWER_STATE_HANDLER_TYPE,
         Context: *mut std::ffi::c_void,
-        Entering: BOOLEAN,
+        Entering: bool,
     ) -> NTSTATUS,
 >;
 
@@ -944,7 +944,7 @@ impl std::fmt::Debug for POWER_STATE_NOTIFY_HANDLER {
 pub struct POWER_REQUEST_ACTION_INTERNAL {
     pub PowerRequestPointer: *mut std::ffi::c_void,
     pub RequestType: POWER_REQUEST_TYPE_INTERNAL,
-    pub SetAction: BOOLEAN,
+    pub SetAction: bool,
 }
 
 impl Default for POWER_REQUEST_ACTION_INTERNAL {
@@ -1099,12 +1099,12 @@ impl std::fmt::Debug for POWER_S0_LOW_POWER_IDLE_INFO_1 {
 
 impl POWER_S0_LOW_POWER_IDLE_INFO_1 {
     #[inline]
-    pub fn Storage(&self) -> BOOLEAN {
+    pub fn Storage(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.as_ref().get(0usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_Storage(&mut self, val: BOOLEAN) {
+    pub fn set_Storage(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -1113,12 +1113,12 @@ impl POWER_S0_LOW_POWER_IDLE_INFO_1 {
     }
 
     #[inline]
-    pub fn WiFi(&self) -> BOOLEAN {
+    pub fn WiFi(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.as_ref().get(1usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_WiFi(&mut self, val: BOOLEAN) {
+    pub fn set_WiFi(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -1127,12 +1127,12 @@ impl POWER_S0_LOW_POWER_IDLE_INFO_1 {
     }
 
     #[inline]
-    pub fn Mbn(&self) -> BOOLEAN {
+    pub fn Mbn(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.as_ref().get(2usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_Mbn(&mut self, val: BOOLEAN) {
+    pub fn set_Mbn(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -1141,12 +1141,12 @@ impl POWER_S0_LOW_POWER_IDLE_INFO_1 {
     }
 
     #[inline]
-    pub fn Ethernet(&self) -> BOOLEAN {
+    pub fn Ethernet(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.as_ref().get(3usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_Ethernet(&mut self, val: BOOLEAN) {
+    pub fn set_Ethernet(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -1155,12 +1155,12 @@ impl POWER_S0_LOW_POWER_IDLE_INFO_1 {
     }
 
     #[inline]
-    pub fn Reserved(&self) -> BOOLEAN {
+    pub fn Reserved(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.as_ref().get(4usize, 4u8) as u8) }
     }
 
     #[inline]
-    pub fn set_Reserved(&mut self, val: BOOLEAN) {
+    pub fn set_Reserved(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -1170,11 +1170,11 @@ impl POWER_S0_LOW_POWER_IDLE_INFO_1 {
 
     #[inline]
     pub fn new_bitfield_1(
-        Storage: BOOLEAN,
-        WiFi: BOOLEAN,
-        Mbn: BOOLEAN,
-        Ethernet: BOOLEAN,
-        Reserved: BOOLEAN,
+        Storage: bool,
+        WiFi: bool,
+        Mbn: bool,
+        Ethernet: bool,
+        Reserved: bool,
     ) -> BitfieldUnit<[u8; 1]> {
         let mut bitfield_unit: BitfieldUnit<[u8; 1]> = Default::default();
 
@@ -1234,12 +1234,12 @@ impl std::fmt::Debug for POWER_S0_LOW_POWER_IDLE_INFO_2 {
 
 impl POWER_S0_LOW_POWER_IDLE_INFO_2 {
     #[inline]
-    pub fn DisconnectInStandby(&self) -> BOOLEAN {
+    pub fn DisconnectInStandby(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.as_ref().get(0usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_DisconnectInStandby(&mut self, val: BOOLEAN) {
+    pub fn set_DisconnectInStandby(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -1248,12 +1248,12 @@ impl POWER_S0_LOW_POWER_IDLE_INFO_2 {
     }
 
     #[inline]
-    pub fn EnforceDs(&self) -> BOOLEAN {
+    pub fn EnforceDs(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.as_ref().get(1usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_EnforceDs(&mut self, val: BOOLEAN) {
+    pub fn set_EnforceDs(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -1262,12 +1262,12 @@ impl POWER_S0_LOW_POWER_IDLE_INFO_2 {
     }
 
     #[inline]
-    pub fn Reserved(&self) -> BOOLEAN {
+    pub fn Reserved(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.as_ref().get(2usize, 6u8) as u8) }
     }
 
     #[inline]
-    pub fn set_Reserved(&mut self, val: BOOLEAN) {
+    pub fn set_Reserved(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -1277,9 +1277,9 @@ impl POWER_S0_LOW_POWER_IDLE_INFO_2 {
 
     #[inline]
     pub fn new_bitfield_1(
-        DisconnectInStandby: BOOLEAN,
-        EnforceDs: BOOLEAN,
-        Reserved: BOOLEAN,
+        DisconnectInStandby: bool,
+        EnforceDs: bool,
+        Reserved: bool,
     ) -> BitfieldUnit<[u8; 1]> {
         let mut bitfield_unit: BitfieldUnit<[u8; 1]> = Default::default();
 
@@ -1367,7 +1367,7 @@ impl std::fmt::Debug for POWER_USER_ABSENCE_PREDICTION {
 
 #[repr(C)]
 pub struct POWER_USER_ABSENCE_PREDICTION_CAPABILITY {
-    pub AbsencePredictionCapability: BOOLEAN,
+    pub AbsencePredictionCapability: bool,
 }
 
 impl Default for POWER_USER_ABSENCE_PREDICTION_CAPABILITY {
@@ -1407,7 +1407,7 @@ impl std::fmt::Debug for POWER_PROCESSOR_LATENCY_HINT {
 #[repr(C)]
 pub struct POWER_STANDBY_NETWORK_REQUEST {
     pub PowerInformationInternalHeader: POWER_INFORMATION_INTERNAL_HEADER,
-    pub Active: BOOLEAN,
+    pub Active: bool,
 }
 
 impl Default for POWER_STANDBY_NETWORK_REQUEST {
@@ -1429,7 +1429,7 @@ impl std::fmt::Debug for POWER_STANDBY_NETWORK_REQUEST {
 #[repr(C)]
 pub struct POWER_SET_BACKGROUND_TASK_STATE {
     pub PowerInformationInternalHeader: POWER_INFORMATION_INTERNAL_HEADER,
-    pub Engaged: BOOLEAN,
+    pub Engaged: bool,
 }
 
 impl Default for POWER_SET_BACKGROUND_TASK_STATE {
@@ -1476,8 +1476,8 @@ impl std::fmt::Debug for POWER_BOOT_SESSION_STANDBY_ACTIVATION_INFO {
 pub struct POWER_SESSION_POWER_STATE {
     pub Header: POWER_INFORMATION_INTERNAL_HEADER,
     pub SessionId: u32,
-    pub On: BOOLEAN,
-    pub IsConsole: BOOLEAN,
+    pub On: bool,
+    pub IsConsole: bool,
     pub RequestReason: POWER_MONITOR_REQUEST_REASON,
 }
 
@@ -1499,9 +1499,9 @@ impl std::fmt::Debug for POWER_SESSION_POWER_STATE {
 
 #[repr(C)]
 pub struct POWER_INTERNAL_PROCESSOR_QOS_SUPPORT {
-    pub QosSupportedAndConfigured: BOOLEAN,
-    pub SchedulerDirectedPerfStatesSupported: BOOLEAN,
-    pub QosGroupPolicyDisable: BOOLEAN,
+    pub QosSupportedAndConfigured: bool,
+    pub SchedulerDirectedPerfStatesSupported: bool,
+    pub QosGroupPolicyDisable: bool,
 }
 
 impl Default for POWER_INTERNAL_PROCESSOR_QOS_SUPPORT {
@@ -1519,7 +1519,7 @@ impl std::fmt::Debug for POWER_INTERNAL_PROCESSOR_QOS_SUPPORT {
 #[repr(C)]
 pub struct POWER_INTERNAL_HOST_ENERGY_SAVER_STATE {
     pub Header: POWER_INFORMATION_INTERNAL_HEADER,
-    pub EsEnabledOnHost: BOOLEAN,
+    pub EsEnabledOnHost: bool,
 }
 
 impl Default for POWER_INTERNAL_HOST_ENERGY_SAVER_STATE {
@@ -1610,7 +1610,7 @@ extern "system" {
         SystemAction: POWER_ACTION,
         LightestSystemState: SYSTEM_POWER_STATE,
         Flags: u32,
-        Asynchronous: BOOLEAN,
+        Asynchronous: bool,
     ) -> NTSTATUS;
 }
 
@@ -1630,5 +1630,5 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn NtIsSystemResumeAutomatic() -> BOOLEAN;
+    pub fn NtIsSystemResumeAutomatic() -> bool;
 }

--- a/src/ntpoapi.rs
+++ b/src/ntpoapi.rs
@@ -443,7 +443,7 @@ impl std::fmt::Debug for PROCESSOR_IDLE_TIMES {
     }
 }
 
-pub type PROCESSOR_IDLE_HANDLER = std::option::Option<
+pub type PROCESSOR_IDLE_HANDLER = Option<
     unsafe extern "system" fn(Context: usize, IdleTimes: *mut PROCESSOR_IDLE_TIMES) -> NTSTATUS,
 >;
 
@@ -871,11 +871,11 @@ pub enum POWER_STATE_HANDLER_TYPE {
     PowerStateMaximum = 7,
 }
 
-pub type PENTER_STATE_SYSTEM_HANDLER = std::option::Option<
+pub type PENTER_STATE_SYSTEM_HANDLER = Option<
     unsafe extern "system" fn(SystemContext: *mut std::ffi::c_void) -> NTSTATUS,
 >;
 
-pub type PENTER_STATE_HANDLER = std::option::Option<
+pub type PENTER_STATE_HANDLER = Option<
     unsafe extern "system" fn(
         Context: *mut std::ffi::c_void,
         SystemHandler: PENTER_STATE_SYSTEM_HANDLER,
@@ -910,7 +910,7 @@ impl std::fmt::Debug for POWER_STATE_HANDLER {
     }
 }
 
-pub type PENTER_STATE_NOTIFY_HANDLER = std::option::Option<
+pub type PENTER_STATE_NOTIFY_HANDLER = Option<
     unsafe extern "system" fn(
         State: POWER_STATE_HANDLER_TYPE,
         Context: *mut std::ffi::c_void,
@@ -1106,8 +1106,6 @@ impl POWER_S0_LOW_POWER_IDLE_INFO_1 {
     #[inline]
     pub fn set_Storage(&mut self, val: bool) {
         unsafe {
-            let val: u8 = std::mem::transmute(val);
-
             self._bitfield_1.as_mut().set(0usize, 1u8, val as u64)
         }
     }
@@ -1120,8 +1118,6 @@ impl POWER_S0_LOW_POWER_IDLE_INFO_1 {
     #[inline]
     pub fn set_WiFi(&mut self, val: bool) {
         unsafe {
-            let val: u8 = std::mem::transmute(val);
-
             self._bitfield_1.as_mut().set(1usize, 1u8, val as u64)
         }
     }
@@ -1134,8 +1130,6 @@ impl POWER_S0_LOW_POWER_IDLE_INFO_1 {
     #[inline]
     pub fn set_Mbn(&mut self, val: bool) {
         unsafe {
-            let val: u8 = std::mem::transmute(val);
-
             self._bitfield_1.as_mut().set(2usize, 1u8, val as u64)
         }
     }
@@ -1148,8 +1142,6 @@ impl POWER_S0_LOW_POWER_IDLE_INFO_1 {
     #[inline]
     pub fn set_Ethernet(&mut self, val: bool) {
         unsafe {
-            let val: u8 = std::mem::transmute(val);
-
             self._bitfield_1.as_mut().set(3usize, 1u8, val as u64)
         }
     }
@@ -1162,8 +1154,6 @@ impl POWER_S0_LOW_POWER_IDLE_INFO_1 {
     #[inline]
     pub fn set_Reserved(&mut self, val: bool) {
         unsafe {
-            let val: u8 = std::mem::transmute(val);
-
             self._bitfield_1.as_mut().set(4usize, 4u8, val as u64)
         }
     }
@@ -1179,32 +1169,22 @@ impl POWER_S0_LOW_POWER_IDLE_INFO_1 {
         let mut bitfield_unit: BitfieldUnit<[u8; 1]> = Default::default();
 
         bitfield_unit.set(0usize, 1u8, {
-            let Storage: u8 = unsafe { std::mem::transmute(Storage) };
-
             Storage as u64
         });
 
         bitfield_unit.set(1usize, 1u8, {
-            let WiFi: u8 = unsafe { std::mem::transmute(WiFi) };
-
             WiFi as u64
         });
 
         bitfield_unit.set(2usize, 1u8, {
-            let Mbn: u8 = unsafe { std::mem::transmute(Mbn) };
-
             Mbn as u64
         });
 
         bitfield_unit.set(3usize, 1u8, {
-            let Ethernet: u8 = unsafe { std::mem::transmute(Ethernet) };
-
             Ethernet as u64
         });
 
         bitfield_unit.set(4usize, 4u8, {
-            let Reserved: u8 = unsafe { std::mem::transmute(Reserved) };
-
             Reserved as u64
         });
 
@@ -1241,8 +1221,6 @@ impl POWER_S0_LOW_POWER_IDLE_INFO_2 {
     #[inline]
     pub fn set_DisconnectInStandby(&mut self, val: bool) {
         unsafe {
-            let val: u8 = std::mem::transmute(val);
-
             self._bitfield_1.as_mut().set(0usize, 1u8, val as u64)
         }
     }
@@ -1255,8 +1233,6 @@ impl POWER_S0_LOW_POWER_IDLE_INFO_2 {
     #[inline]
     pub fn set_EnforceDs(&mut self, val: bool) {
         unsafe {
-            let val: u8 = std::mem::transmute(val);
-
             self._bitfield_1.as_mut().set(1usize, 1u8, val as u64)
         }
     }
@@ -1269,8 +1245,6 @@ impl POWER_S0_LOW_POWER_IDLE_INFO_2 {
     #[inline]
     pub fn set_Reserved(&mut self, val: bool) {
         unsafe {
-            let val: u8 = std::mem::transmute(val);
-
             self._bitfield_1.as_mut().set(2usize, 6u8, val as u64)
         }
     }
@@ -1284,20 +1258,14 @@ impl POWER_S0_LOW_POWER_IDLE_INFO_2 {
         let mut bitfield_unit: BitfieldUnit<[u8; 1]> = Default::default();
 
         bitfield_unit.set(0usize, 1u8, {
-            let DisconnectInStandby: u8 = unsafe { std::mem::transmute(DisconnectInStandby) };
-
             DisconnectInStandby as u64
         });
 
         bitfield_unit.set(1usize, 1u8, {
-            let EnforceDs: u8 = unsafe { std::mem::transmute(EnforceDs) };
-
             EnforceDs as u64
         });
 
         bitfield_unit.set(2usize, 6u8, {
-            let Reserved: u8 = unsafe { std::mem::transmute(Reserved) };
-
             Reserved as u64
         });
 

--- a/src/ntpsapi.rs
+++ b/src/ntpsapi.rs
@@ -8,7 +8,7 @@ use windows::{
         },
     },
     Win32::{
-        Foundation::{BOOL, BOOLEAN, HANDLE, NTSTATUS, UNICODE_STRING},
+        Foundation::{HANDLE, NTSTATUS, UNICODE_STRING},
         Security::SECURITY_QUALITY_OF_SERVICE,
         System::{
             Diagnostics::Debug::{CONTEXT, LDT_ENTRY},
@@ -194,13 +194,13 @@ pub const ProcThreadAttributeCreateStore: u32 = 28;
 #[repr(C)]
 pub struct PEB_LDR_DATA {
     pub Length: u32,
-    pub Initialized: BOOLEAN,
+    pub Initialized: bool,
     pub SsHandle: HANDLE,
     pub InLoadOrderModuleList: LIST_ENTRY,
     pub InMemoryOrderModuleList: LIST_ENTRY,
     pub InInitializationOrderModuleList: LIST_ENTRY,
     pub EntryInProgress: *mut std::ffi::c_void,
-    pub ShutdownInProgress: BOOLEAN,
+    pub ShutdownInProgress: bool,
     pub ShutdownThreadId: HANDLE,
 }
 
@@ -336,7 +336,7 @@ impl std::fmt::Debug for PROCESS_WS_WATCH_INFORMATION_EX {
 
 #[repr(C)]
 pub struct PROCESS_PRIORITY_CLASS {
-    pub Foreground: BOOLEAN,
+    pub Foreground: bool,
     pub PriorityClass: u8,
 }
 
@@ -356,7 +356,7 @@ impl std::fmt::Debug for PROCESS_PRIORITY_CLASS {
 pub struct PROCESS_PRIORITY_CLASS_EX {
     pub Anonymous1: PROCESS_PRIORITY_CLASS_EX_1,
     pub PriorityClass: u8,
-    pub Foreground: BOOLEAN,
+    pub Foreground: bool,
 }
 
 #[repr(C)]
@@ -454,7 +454,7 @@ impl std::fmt::Debug for PROCESS_PRIORITY_CLASS_EX {
 
 #[repr(C)]
 pub struct PROCESS_FOREGROUND_BACKGROUND {
-    pub Foreground: BOOLEAN,
+    pub Foreground: bool,
 }
 
 impl Default for PROCESS_FOREGROUND_BACKGROUND {
@@ -1263,9 +1263,9 @@ impl std::fmt::Debug for PROCESS_JOB_MEMORY_INFO {
 
 #[repr(C)]
 pub struct PROCESS_CHILD_PROCESS_INFORMATION {
-    pub ProhibitChildProcesses: BOOLEAN,
-    pub AlwaysAllowSecureChildProcess: BOOLEAN,
-    pub AuditProhibitChildProcesses: BOOLEAN,
+    pub ProhibitChildProcesses: bool,
+    pub AlwaysAllowSecureChildProcess: bool,
+    pub AuditProhibitChildProcesses: bool,
 }
 
 impl Default for PROCESS_CHILD_PROCESS_INFORMATION {
@@ -2598,7 +2598,7 @@ extern "system" {
         DesiredAccess: u32,
         ObjectAttributes: *mut OBJECT_ATTRIBUTES,
         ParentProcess: HANDLE,
-        InheritObjectTable: BOOLEAN,
+        InheritObjectTable: bool,
         SectionHandle: HANDLE,
         DebugPort: HANDLE,
         TokenHandle: HANDLE,
@@ -2740,7 +2740,7 @@ extern "system" {
         ClientId: *mut CLIENT_ID,
         ThreadContext: *mut CONTEXT,
         InitialTeb: *mut INITIAL_TEB,
-        CreateSuspended: BOOLEAN,
+        CreateSuspended: bool,
     ) -> NTSTATUS;
 }
 
@@ -2968,7 +2968,7 @@ impl std::fmt::Debug for SE_SAFE_OPEN_PROMPT_RESULTS {
 
 #[repr(C)]
 pub struct PROC_THREAD_BNOISOLATION_ATTRIBUTE {
-    pub IsolationEnabled: BOOL,
+    pub IsolationEnabled: bool,
     pub IsolationPrefix: [u16; 136],
 }
 
@@ -3498,7 +3498,7 @@ pub struct PS_BNO_ISOLATION_PARAMETERS {
     pub IsolationPrefix: UNICODE_STRING,
     pub HandleCount: u32,
     pub Handles: *mut *mut std::ffi::c_void,
-    pub IsolationEnabled: BOOLEAN,
+    pub IsolationEnabled: bool,
 }
 
 impl Default for PS_BNO_ISOLATION_PARAMETERS {
@@ -4209,8 +4209,8 @@ impl std::fmt::Debug for JOBOBJECT_WAKE_FILTER {
 #[repr(C)]
 pub struct JOBOBJECT_FREEZE_INFORMATION {
     pub Anonymous1: JOBOBJECT_FREEZE_INFORMATION_1,
-    pub Freeze: BOOLEAN,
-    pub Swap: BOOLEAN,
+    pub Freeze: bool,
+    pub Swap: bool,
     pub Reserved0: [u8; 2],
     pub WakeFilter: JOBOBJECT_WAKE_FILTER,
 }
@@ -4406,7 +4406,7 @@ pub struct SILO_USER_SHARED_DATA {
     pub NtProductType: NT_PRODUCT_TYPE,
     pub SuiteMask: u32,
     pub SharedUserSessionId: u32,
-    pub IsMultiSessionSku: BOOLEAN,
+    pub IsMultiSessionSku: bool,
     pub NtSystemRoot: [u16; 260],
     pub UserModeGlobalLogger: [u16; 16],
     pub TimeZoneId: u32,
@@ -4478,7 +4478,7 @@ impl std::fmt::Debug for SILOOBJECT_ROOT_DIRECTORY {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct SERVERSILO_INIT_INFORMATION {
     pub DeleteEvent: HANDLE,
-    pub IsDownlevelContainer: BOOLEAN,
+    pub IsDownlevelContainer: bool,
 }
 
 impl Default for SERVERSILO_INIT_INFORMATION {

--- a/src/ntregapi.rs
+++ b/src/ntregapi.rs
@@ -4,7 +4,7 @@ use windows::{
         System::Registry::{KEY_INFORMATION_CLASS, KEY_VALUE_INFORMATION_CLASS},
     },
     Win32::{
-        Foundation::{BOOLEAN, HANDLE, NTSTATUS, UNICODE_STRING},
+        Foundation::{HANDLE, NTSTATUS, UNICODE_STRING},
         System::IO::{IO_STATUS_BLOCK, PIO_APC_ROUTINE},
     },
 };
@@ -852,10 +852,10 @@ extern "system" {
         ApcContext: *mut std::ffi::c_void,
         IoStatusBlock: *mut IO_STATUS_BLOCK,
         CompletionFilter: u32,
-        WatchTree: BOOLEAN,
+        WatchTree: bool,
         Buffer: *mut std::ffi::c_void,
         BufferSize: u32,
-        Asynchronous: BOOLEAN,
+        Asynchronous: bool,
     ) -> NTSTATUS;
 }
 

--- a/src/ntrtl.rs
+++ b/src/ntrtl.rs
@@ -5,7 +5,7 @@ use windows::{
         System::SystemServices::{KSYSTEM_TIME, RTL_BITMAP, RTL_QUERY_REGISTRY_TABLE, TIME_FIELDS},
     },
     Win32::{
-        Foundation::{BOOL, BOOLEAN, HANDLE, LUID, NTSTATUS, UNICODE_STRING},
+        Foundation::{HANDLE, LUID, NTSTATUS, UNICODE_STRING},
         Security::{
             ACE_HEADER, ACL, ACL_INFORMATION_CLASS, CLAIM_SECURITY_ATTRIBUTES_INFORMATION,
             GENERIC_MAPPING, LUID_AND_ATTRIBUTES, PSID, SECURITY_DESCRIPTOR,
@@ -285,14 +285,14 @@ extern "system" {
     pub fn RtlRbInsertNodeEx(
         Tree: *mut RTL_RB_TREE,
         Parent: *mut RTL_BALANCED_NODE,
-        Right: BOOLEAN,
+        Right: bool,
         Node: *mut RTL_BALANCED_NODE,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlRbRemoveNode(Tree: *mut RTL_RB_TREE, Node: *mut RTL_BALANCED_NODE) -> BOOLEAN;
+    pub fn RtlRbRemoveNode(Tree: *mut RTL_RB_TREE, Node: *mut RTL_BALANCED_NODE) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -407,12 +407,12 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlAcquireResourceShared(Resource: *mut RTL_RESOURCE, Wait: BOOLEAN) -> BOOLEAN;
+    pub fn RtlAcquireResourceShared(Resource: *mut RTL_RESOURCE, Wait: bool) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlAcquireResourceExclusive(Resource: *mut RTL_RESOURCE, Wait: BOOLEAN) -> BOOLEAN;
+    pub fn RtlAcquireResourceExclusive(Resource: *mut RTL_RESOURCE, Wait: bool) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -457,12 +457,12 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlTryAcquireSRWLockExclusive(SRWLock: *mut SRWLOCK) -> BOOLEAN;
+    pub fn RtlTryAcquireSRWLockExclusive(SRWLock: *mut SRWLOCK) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlTryAcquireSRWLockShared(SRWLock: *mut SRWLOCK) -> BOOLEAN;
+    pub fn RtlTryAcquireSRWLockShared(SRWLock: *mut SRWLOCK) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -520,12 +520,12 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlBarrier(Barrier: *mut SYNCHRONIZATION_BARRIER, Flags: u32) -> BOOLEAN;
+    pub fn RtlBarrier(Barrier: *mut SYNCHRONIZATION_BARRIER, Flags: u32) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlBarrierForDelete(Barrier: *mut SYNCHRONIZATION_BARRIER, Flags: u32) -> BOOLEAN;
+    pub fn RtlBarrierForDelete(Barrier: *mut SYNCHRONIZATION_BARRIER, Flags: u32) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -558,7 +558,7 @@ extern "system" {
     pub fn RtlCreateUnicodeStringFromAsciiz(
         DestinationString: *mut UNICODE_STRING,
         SourceString: *mut i8,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -566,7 +566,7 @@ extern "system" {
     pub fn RtlFindUnicodeSubstring(
         FullString: *mut UNICODE_STRING,
         SearchString: *mut UNICODE_STRING,
-        CaseInSensitive: BOOLEAN,
+        CaseInSensitive: bool,
     ) -> PWSTR;
 }
 
@@ -595,7 +595,7 @@ extern "system" {
     pub fn RtlUpcaseUnicodeStringToAnsiString(
         DestinationString: *mut STRING,
         SourceString: *mut UNICODE_STRING,
-        AllocateDestinationString: BOOLEAN,
+        AllocateDestinationString: bool,
     ) -> NTSTATUS;
 }
 
@@ -628,7 +628,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlIsTextUnicode(Buffer: *mut std::ffi::c_void, Size: u32, Result: *mut u32) -> BOOLEAN;
+    pub fn RtlIsTextUnicode(Buffer: *mut std::ffi::c_void, Size: u32, Result: *mut u32) -> bool;
 }
 
 #[repr(i32)]
@@ -653,9 +653,9 @@ extern "system" {
     pub fn RtlIsNameInExpression(
         Expression: *mut UNICODE_STRING,
         Name: *mut UNICODE_STRING,
-        IgnoreCase: BOOLEAN,
+        IgnoreCase: bool,
         UpcaseTable: PWSTR,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -663,14 +663,14 @@ extern "system" {
     pub fn RtlIsNameInUnUpcasedExpression(
         Expression: *mut UNICODE_STRING,
         Name: *mut UNICODE_STRING,
-        IgnoreCase: BOOLEAN,
+        IgnoreCase: bool,
         UpcaseTable: PWSTR,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlDoesNameContainWildCards(Expression: *mut UNICODE_STRING) -> BOOLEAN;
+    pub fn RtlDoesNameContainWildCards(Expression: *mut UNICODE_STRING) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -678,7 +678,7 @@ extern "system" {
     pub fn RtlEqualDomainName(
         String1: *mut UNICODE_STRING,
         String2: *mut UNICODE_STRING,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -686,7 +686,7 @@ extern "system" {
     pub fn RtlEqualComputerName(
         String1: *mut UNICODE_STRING,
         String2: *mut UNICODE_STRING,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -694,7 +694,7 @@ extern "system" {
     pub fn RtlDnsHostNameToComputerName(
         ComputerNameString: *mut UNICODE_STRING,
         DnsHostNameString: *mut UNICODE_STRING,
-        AllocateComputerNameString: BOOLEAN,
+        AllocateComputerNameString: bool,
     ) -> NTSTATUS;
 }
 
@@ -703,7 +703,7 @@ extern "system" {
     pub fn RtlStringFromGUIDEx(
         Guid: *mut GUID,
         GuidString: *mut UNICODE_STRING,
-        AllocateGuidString: BOOLEAN,
+        AllocateGuidString: bool,
     ) -> NTSTATUS;
 }
 
@@ -720,7 +720,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlIsValidLocaleName(LocaleName: PCWSTR, Flags: u32) -> BOOLEAN;
+    pub fn RtlIsValidLocaleName(LocaleName: PCWSTR, Flags: u32) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -729,7 +729,7 @@ extern "system" {
         LocaleName: PCWSTR,
         ParentLocaleName: *mut UNICODE_STRING,
         Flags: u32,
-        AllocateDestinationString: BOOLEAN,
+        AllocateDestinationString: bool,
     ) -> NTSTATUS;
 }
 
@@ -739,7 +739,7 @@ extern "system" {
         lcid: u32,
         LocaleName: *mut UNICODE_STRING,
         Flags: u32,
-        AllocateDestinationString: BOOLEAN,
+        AllocateDestinationString: bool,
     ) -> NTSTATUS;
 }
 
@@ -750,12 +750,12 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlLCIDToCultureName(Lcid: u32, String: *mut UNICODE_STRING) -> BOOLEAN;
+    pub fn RtlLCIDToCultureName(Lcid: u32, String: *mut UNICODE_STRING) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlCultureNameToLCID(String: *mut UNICODE_STRING, Lcid: *mut u32) -> BOOLEAN;
+    pub fn RtlCultureNameToLCID(String: *mut UNICODE_STRING, Lcid: *mut u32) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -983,7 +983,7 @@ extern "system" {
         ProcessSecurityDescriptor: *mut SECURITY_DESCRIPTOR,
         ThreadSecurityDescriptor: *mut SECURITY_DESCRIPTOR,
         ParentProcess: HANDLE,
-        InheritHandles: BOOLEAN,
+        InheritHandles: bool,
         DebugPort: HANDLE,
         TokenHandle: HANDLE,
         ProcessInformation: *mut RTL_USER_PROCESS_INFORMATION,
@@ -1019,7 +1019,7 @@ extern "system" {
     pub fn RtlCreateUserProcessEx(
         NtImagePathName: *mut UNICODE_STRING,
         ProcessParameters: *mut RTL_USER_PROCESS_PARAMETERS,
-        InheritHandles: BOOLEAN,
+        InheritHandles: bool,
         ProcessExtendedParameters: *mut RTL_USER_PROCESS_EXTENDED_PARAMETERS,
         ProcessInformation: *mut RTL_USER_PROCESS_INFORMATION,
     ) -> NTSTATUS;
@@ -1085,39 +1085,39 @@ extern "system" {
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn RtlSetProcessIsCritical(
-        NewValue: BOOLEAN,
-        OldValue: *mut BOOLEAN,
-        CheckFlag: BOOLEAN,
+        NewValue: bool,
+        OldValue: *mut bool,
+        CheckFlag: bool,
     ) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn RtlSetThreadIsCritical(
-        NewValue: BOOLEAN,
-        OldValue: *mut BOOLEAN,
-        CheckFlag: BOOLEAN,
+        NewValue: bool,
+        OldValue: *mut bool,
+        CheckFlag: bool,
     ) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlValidProcessProtection(ProcessProtection: PS_PROTECTION) -> BOOLEAN;
+    pub fn RtlValidProcessProtection(ProcessProtection: PS_PROTECTION) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlTestProtectedAccess(Source: PS_PROTECTION, Target: PS_PROTECTION) -> BOOLEAN;
+    pub fn RtlTestProtectedAccess(Source: PS_PROTECTION, Target: PS_PROTECTION) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlIsCurrentProcess(ProcessHandle: HANDLE) -> BOOLEAN;
+    pub fn RtlIsCurrentProcess(ProcessHandle: HANDLE) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlIsCurrentThread(ThreadHandle: HANDLE) -> BOOLEAN;
+    pub fn RtlIsCurrentThread(ThreadHandle: HANDLE) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -1125,7 +1125,7 @@ extern "system" {
     pub fn RtlCreateUserThread(
         ProcessHandle: HANDLE,
         ThreadSecurityDescriptor: *mut SECURITY_DESCRIPTOR,
-        CreateSuspended: BOOLEAN,
+        CreateSuspended: bool,
         ZeroBits: u32,
         MaximumStackSize: usize,
         CommittedStackSize: usize,
@@ -1143,7 +1143,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlIsCurrentThreadAttachExempt() -> BOOLEAN;
+    pub fn RtlIsCurrentThreadAttachExempt() -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -1315,8 +1315,8 @@ extern "system" {
         CallSite: *mut std::ffi::c_void,
         ArgumentCount: u32,
         Arguments: *mut usize,
-        PassContext: BOOLEAN,
-        AlreadySuspended: BOOLEAN,
+        PassContext: bool,
+        AlreadySuspended: bool,
     ) -> NTSTATUS;
 }
 
@@ -1439,7 +1439,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlIsActivationContextActive(ActivationContext: *mut ACTIVATION_CONTEXT) -> BOOLEAN;
+    pub fn RtlIsActivationContextActive(ActivationContext: *mut ACTIVATION_CONTEXT) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -1573,7 +1573,7 @@ extern "system" {
 extern "system" {
     pub fn RtlImageDirectoryEntryToData(
         BaseOfImage: *mut std::ffi::c_void,
-        MappedAsImage: BOOLEAN,
+        MappedAsImage: bool,
         DirectoryEntry: u16,
         Size: *mut u32,
     ) -> *mut std::ffi::c_void;
@@ -1610,15 +1610,15 @@ extern "system" {
 extern "system" {
     pub fn RtlGuardCheckLongJumpTarget(
         PcValue: *mut std::ffi::c_void,
-        IsFastFail: BOOL,
-        IsLongJumpTarget: *mut BOOL,
+        IsFastFail: bool,
+        IsLongJumpTarget: *mut bool,
     ) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn RtlCreateEnvironment(
-        CloneCurrentEnvironment: BOOLEAN,
+        CloneCurrentEnvironment: bool,
         Environment: *mut *mut std::ffi::c_void,
     ) -> NTSTATUS;
 }
@@ -1806,7 +1806,7 @@ extern "system" {
         DynamicString: *mut UNICODE_STRING,
         StringUsed: *mut *mut UNICODE_STRING,
         FilePartPrefixCch: *mut usize,
-        NameInvalid: *mut BOOLEAN,
+        NameInvalid: *mut bool,
         InputPathType: *mut RTL_PATH_TYPE,
         BytesRequired: *mut usize,
     ) -> NTSTATUS;
@@ -1887,7 +1887,7 @@ extern "system" {
         NtFileName: *mut UNICODE_STRING,
         FilePart: *mut PWSTR,
         RelativeName: *mut RTL_RELATIVE_NAME_U,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -1917,7 +1917,7 @@ extern "system" {
         NtFileName: *mut UNICODE_STRING,
         FilePart: *mut PWSTR,
         RelativeName: *mut RTL_RELATIVE_NAME_U,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -1974,7 +1974,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlDoesFileExists_U(FileName: PCWSTR) -> BOOLEAN;
+    pub fn RtlDoesFileExists_U(FileName: PCWSTR) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2045,7 +2045,7 @@ extern "system" {
         Destination: *mut UNICODE_STRING,
         Machine: u16,
         TargetMachine: u16,
-        IncludePathSeperator: BOOLEAN,
+        IncludePathSeperator: bool,
     ) -> u32;
 }
 
@@ -2065,17 +2065,17 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlAreLongPathsEnabled() -> BOOLEAN;
+    pub fn RtlAreLongPathsEnabled() -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlIsThreadWithinLoaderCallout() -> BOOLEAN;
+    pub fn RtlIsThreadWithinLoaderCallout() -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlDllShutdownInProgress() -> BOOLEAN;
+    pub fn RtlDllShutdownInProgress() -> bool;
 }
 
 #[repr(C)]
@@ -2294,17 +2294,17 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlProtectHeap(HeapHandle: *mut std::ffi::c_void, MakeReadOnly: BOOLEAN);
+    pub fn RtlProtectHeap(HeapHandle: *mut std::ffi::c_void, MakeReadOnly: bool);
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlLockHeap(HeapHandle: *mut std::ffi::c_void) -> BOOLEAN;
+    pub fn RtlLockHeap(HeapHandle: *mut std::ffi::c_void) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlUnlockHeap(HeapHandle: *mut std::ffi::c_void) -> BOOLEAN;
+    pub fn RtlUnlockHeap(HeapHandle: *mut std::ffi::c_void) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2325,7 +2325,7 @@ extern "system" {
         BaseAddress: *mut std::ffi::c_void,
         UserValue: *mut *mut std::ffi::c_void,
         UserFlags: *mut u32,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2335,7 +2335,7 @@ extern "system" {
         Flags: u32,
         BaseAddress: *mut std::ffi::c_void,
         UserValue: *mut std::ffi::c_void,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2346,7 +2346,7 @@ extern "system" {
         BaseAddress: *mut std::ffi::c_void,
         UserFlagsReset: u32,
         UserFlagsSet: u32,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[repr(C)]
@@ -2384,7 +2384,7 @@ extern "system" {
         HeapHandle: *mut std::ffi::c_void,
         Flags: u32,
         TagIndex: u16,
-        ResetCounters: BOOLEAN,
+        ResetCounters: bool,
         TagInfo: *mut RTL_HEAP_TAG_INFO,
     ) -> PWSTR;
 }
@@ -2410,12 +2410,12 @@ extern "system" {
         HeapHandle: *mut std::ffi::c_void,
         Flags: u32,
         BaseAddress: *mut std::ffi::c_void,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlValidateProcessHeaps() -> BOOLEAN;
+    pub fn RtlValidateProcessHeaps() -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -3404,7 +3404,7 @@ impl std::fmt::Debug for RTL_DEBUG_INFORMATION {
 extern "system" {
     pub fn RtlCreateQueryDebugBuffer(
         MaximumCommit: u32,
-        UseEventPair: BOOLEAN,
+        UseEventPair: bool,
     ) -> *mut RTL_DEBUG_INFORMATION;
 }
 
@@ -3464,9 +3464,9 @@ extern "system" {
     pub fn RtlFormatMessage(
         MessageFormat: PWSTR,
         MaximumWidth: u32,
-        IgnoreInserts: BOOLEAN,
-        ArgumentsAreAnsi: BOOLEAN,
-        ArgumentsAreAnArray: BOOLEAN,
+        IgnoreInserts: bool,
+        ArgumentsAreAnsi: bool,
+        ArgumentsAreAnArray: bool,
         Arguments: *mut *mut std::ffi::c_void,
         Buffer: PWSTR,
         Length: u32,
@@ -3501,9 +3501,9 @@ extern "system" {
     pub fn RtlFormatMessageEx(
         MessageFormat: PWSTR,
         MaximumWidth: u32,
-        IgnoreInserts: BOOLEAN,
-        ArgumentsAreAnsi: BOOLEAN,
-        ArgumentsAreAnArray: BOOLEAN,
+        IgnoreInserts: bool,
+        ArgumentsAreAnsi: bool,
+        ArgumentsAreAnArray: bool,
         Arguments: *mut *mut std::ffi::c_void,
         Buffer: PWSTR,
         Length: u32,
@@ -3661,8 +3661,8 @@ extern "system" {
         CutoverTime: *mut TIME_FIELDS,
         SystemTime: *mut i64,
         CurrentSystemTime: *mut i64,
-        ThisYear: BOOLEAN,
-    ) -> BOOLEAN;
+        ThisYear: bool,
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -3696,7 +3696,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlQueryUnbiasedInterruptTime(InterruptTime: *mut i64) -> BOOLEAN;
+    pub fn RtlQueryUnbiasedInterruptTime(InterruptTime: *mut i64) -> bool;
 }
 
 #[repr(C)]
@@ -3787,7 +3787,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlTestBitEx(BitMapHeader: *mut RTL_BITMAP_EX, BitNumber: u64) -> BOOLEAN;
+    pub fn RtlTestBitEx(BitMapHeader: *mut RTL_BITMAP_EX, BitNumber: u64) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -3921,7 +3921,7 @@ extern "system" {
     pub fn RtlFreeHandle(
         HandleTable: *mut RTL_HANDLE_TABLE,
         Handle: *mut RTL_HANDLE_TABLE_ENTRY,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -3929,7 +3929,7 @@ extern "system" {
     pub fn RtlIsValidHandle(
         HandleTable: *mut RTL_HANDLE_TABLE,
         Handle: *mut RTL_HANDLE_TABLE_ENTRY,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -3938,7 +3938,7 @@ extern "system" {
         HandleTable: *mut RTL_HANDLE_TABLE,
         HandleIndex: u32,
         Handle: *mut *mut RTL_HANDLE_TABLE_ENTRY,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -3958,7 +3958,7 @@ extern "system" {
 extern "system" {
     pub fn RtlEmptyAtomTable(
         AtomTableHandle: *mut std::ffi::c_void,
-        IncludePinnedAtoms: BOOLEAN,
+        IncludePinnedAtoms: bool,
     ) -> NTSTATUS;
 }
 
@@ -4007,7 +4007,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlGetIntegerAtom(AtomName: PWSTR, IntegerAtom: *mut u16) -> BOOLEAN;
+    pub fn RtlGetIntegerAtom(AtomName: PWSTR, IntegerAtom: *mut u16) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -4025,7 +4025,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlSidDominates(Sid1: PSID, Sid2: PSID, Dominates: *mut BOOLEAN) -> NTSTATUS;
+    pub fn RtlSidDominates(Sid1: PSID, Sid2: PSID, Dominates: *mut bool) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -4033,18 +4033,18 @@ extern "system" {
     pub fn RtlSidDominatesForTrust(
         Sid1: PSID,
         Sid2: PSID,
-        DominatesTrust: *mut BOOLEAN,
+        DominatesTrust: *mut bool,
     ) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlSidEqualLevel(Sid1: PSID, Sid2: PSID, EqualLevel: *mut BOOLEAN) -> NTSTATUS;
+    pub fn RtlSidEqualLevel(Sid1: PSID, Sid2: PSID, EqualLevel: *mut bool) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlSidIsHigherLevel(Sid1: PSID, Sid2: PSID, HigherLevel: *mut BOOLEAN) -> NTSTATUS;
+    pub fn RtlSidIsHigherLevel(Sid1: PSID, Sid2: PSID, HigherLevel: *mut bool) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -4071,7 +4071,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlIsElevatedRid(SidAttr: *mut SID_AND_ATTRIBUTES) -> BOOLEAN;
+    pub fn RtlIsElevatedRid(SidAttr: *mut SID_AND_ATTRIBUTES) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -4115,7 +4115,7 @@ extern "system" {
     pub fn RtlGetSecurityDescriptorRMControl(
         SecurityDescriptor: *mut SECURITY_DESCRIPTOR,
         RMControl: *mut u8,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -4145,7 +4145,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlValidAcl(Acl: *mut ACL) -> BOOLEAN;
+    pub fn RtlValidAcl(Acl: *mut ACL) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -4170,7 +4170,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlFirstFreeAce(Acl: *mut ACL, FirstFree: *mut *mut std::ffi::c_void) -> BOOLEAN;
+    pub fn RtlFirstFreeAce(Acl: *mut ACL, FirstFree: *mut *mut std::ffi::c_void) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -4180,7 +4180,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlOwnerAcesPresent(pAcl: *mut ACL) -> BOOLEAN;
+    pub fn RtlOwnerAcesPresent(pAcl: *mut ACL) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -4211,8 +4211,8 @@ extern "system" {
         AceRevision: u32,
         AccessMask: u32,
         Sid: PSID,
-        AuditSuccess: BOOLEAN,
-        AuditFailure: BOOLEAN,
+        AuditSuccess: bool,
+        AuditFailure: bool,
     ) -> NTSTATUS;
 }
 
@@ -4224,8 +4224,8 @@ extern "system" {
         AceFlags: u32,
         AccessMask: u32,
         Sid: PSID,
-        AuditSuccess: BOOLEAN,
-        AuditFailure: BOOLEAN,
+        AuditSuccess: bool,
+        AuditFailure: bool,
     ) -> NTSTATUS;
 }
 
@@ -4265,13 +4265,13 @@ extern "system" {
         ObjectTypeGuid: *mut GUID,
         InheritedObjectTypeGuid: *mut GUID,
         Sid: PSID,
-        AuditSuccess: BOOLEAN,
-        AuditFailure: BOOLEAN,
+        AuditSuccess: bool,
+        AuditFailure: bool,
     ) -> NTSTATUS;
 }
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct COMPOUND_ACCESS_ALLOWED_ACE {
     pub Header: ACE_HEADER,
     pub Mask: u32,
@@ -4339,7 +4339,7 @@ extern "system" {
         ParentDescriptor: *mut SECURITY_DESCRIPTOR,
         CreatorDescriptor: *mut SECURITY_DESCRIPTOR,
         NewDescriptor: *mut *mut SECURITY_DESCRIPTOR,
-        IsDirectoryObject: BOOLEAN,
+        IsDirectoryObject: bool,
         Token: HANDLE,
         GenericMapping: *mut GENERIC_MAPPING,
     ) -> NTSTATUS;
@@ -4352,7 +4352,7 @@ extern "system" {
         CreatorDescriptor: *mut SECURITY_DESCRIPTOR,
         NewDescriptor: *mut *mut SECURITY_DESCRIPTOR,
         ObjectType: *mut GUID,
-        IsDirectoryObject: BOOLEAN,
+        IsDirectoryObject: bool,
         AutoInheritFlags: u32,
         Token: HANDLE,
         GenericMapping: *mut GENERIC_MAPPING,
@@ -4367,7 +4367,7 @@ extern "system" {
         NewDescriptor: *mut *mut SECURITY_DESCRIPTOR,
         ObjectType: *mut *mut GUID,
         GuidCount: u32,
-        IsDirectoryObject: BOOLEAN,
+        IsDirectoryObject: bool,
         AutoInheritFlags: u32,
         Token: HANDLE,
         GenericMapping: *mut GENERIC_MAPPING,
@@ -4420,7 +4420,7 @@ extern "system" {
         CurrentSecurityDescriptor: *mut SECURITY_DESCRIPTOR,
         NewSecurityDescriptor: *mut *mut SECURITY_DESCRIPTOR,
         ObjectType: *mut GUID,
-        IsDirectoryObject: BOOLEAN,
+        IsDirectoryObject: bool,
         GenericMapping: *mut GENERIC_MAPPING,
     ) -> NTSTATUS;
 }
@@ -4428,14 +4428,14 @@ extern "system" {
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
     pub fn RtlNewInstanceSecurityObject(
-        ParentDescriptorChanged: BOOLEAN,
-        CreatorDescriptorChanged: BOOLEAN,
+        ParentDescriptorChanged: bool,
+        CreatorDescriptorChanged: bool,
         OldClientTokenModifiedId: *mut LUID,
         NewClientTokenModifiedId: *mut LUID,
         ParentDescriptor: *mut SECURITY_DESCRIPTOR,
         CreatorDescriptor: *mut SECURITY_DESCRIPTOR,
         NewDescriptor: *mut *mut SECURITY_DESCRIPTOR,
-        IsDirectoryObject: BOOLEAN,
+        IsDirectoryObject: bool,
         TokenHandle: HANDLE,
         GenericMapping: *mut GENERIC_MAPPING,
     ) -> NTSTATUS;
@@ -4477,7 +4477,7 @@ extern "system" {
         AceCount: u32,
         OwnerSid: PSID,
         GroupSid: PSID,
-        IsDirectoryObject: BOOLEAN,
+        IsDirectoryObject: bool,
         GenericMapping: *mut GENERIC_MAPPING,
         NewSecurityDescriptor: *mut *mut SECURITY_DESCRIPTOR,
     ) -> NTSTATUS;
@@ -4522,9 +4522,9 @@ extern "system" {
 extern "system" {
     pub fn RtlAdjustPrivilege(
         Privilege: u32,
-        Enable: BOOLEAN,
-        Client: BOOLEAN,
-        WasEnabled: *mut BOOLEAN,
+        Enable: bool,
+        Client: bool,
+        WasEnabled: *mut bool,
     ) -> NTSTATUS;
 }
 
@@ -4666,7 +4666,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlDelayExecution(Alertable: BOOLEAN, DelayInterval: *mut i64) -> NTSTATUS;
+    pub fn RtlDelayExecution(Alertable: bool, DelayInterval: *mut i64) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -4754,7 +4754,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlQueryThreadProfiling(ThreadHandle: HANDLE, Enabled: *mut BOOLEAN) -> NTSTATUS;
+    pub fn RtlQueryThreadProfiling(ThreadHandle: HANDLE, Enabled: *mut bool) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -4789,7 +4789,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlWow64EnableFsRedirection(Wow64FsEnableRedirection: BOOLEAN) -> NTSTATUS;
+    pub fn RtlWow64EnableFsRedirection(Wow64FsEnableRedirection: bool) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -4845,7 +4845,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlIsProcessorFeaturePresent(ProcessorFeature: u32) -> BOOLEAN;
+    pub fn RtlIsProcessorFeaturePresent(ProcessorFeature: u32) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -5749,7 +5749,7 @@ extern "system" {
     pub fn RtlGetAppContainerNamedObjectPath(
         TokenHandle: HANDLE,
         AppContainerSid: PSID,
-        RelativePath: BOOLEAN,
+        RelativePath: bool,
         ObjectPath: *mut UNICODE_STRING,
     ) -> NTSTATUS;
 }
@@ -5764,7 +5764,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlCheckSandboxedToken(TokenHandle: HANDLE, IsSandboxed: *mut BOOLEAN) -> NTSTATUS;
+    pub fn RtlCheckSandboxedToken(TokenHandle: HANDLE, IsSandboxed: *mut bool) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -5772,7 +5772,7 @@ extern "system" {
     pub fn RtlCheckTokenCapability(
         TokenHandle: HANDLE,
         CapabilitySidToCheck: PSID,
-        HasCapability: *mut BOOLEAN,
+        HasCapability: *mut bool,
     ) -> NTSTATUS;
 }
 
@@ -5781,7 +5781,7 @@ extern "system" {
     pub fn RtlCapabilityCheck(
         TokenHandle: HANDLE,
         CapabilityName: *mut UNICODE_STRING,
-        HasCapability: *mut BOOLEAN,
+        HasCapability: *mut bool,
     ) -> NTSTATUS;
 }
 
@@ -5790,7 +5790,7 @@ extern "system" {
     pub fn RtlCheckTokenMembership(
         TokenHandle: HANDLE,
         SidToCheck: PSID,
-        IsMember: *mut BOOLEAN,
+        IsMember: *mut bool,
     ) -> NTSTATUS;
 }
 
@@ -5800,7 +5800,7 @@ extern "system" {
         TokenHandle: HANDLE,
         SidToCheck: PSID,
         Flags: u32,
-        IsMember: *mut BOOLEAN,
+        IsMember: *mut bool,
     ) -> NTSTATUS;
 }
 
@@ -5814,22 +5814,22 @@ extern "system" {
     pub fn RtlIsParentOfChildAppContainer(
         ParentAppContainerSid: PSID,
         ChildAppContainerSid: PSID,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlIsCapabilitySid(Sid: PSID) -> BOOLEAN;
+    pub fn RtlIsCapabilitySid(Sid: PSID) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlIsPackageSid(Sid: PSID) -> BOOLEAN;
+    pub fn RtlIsPackageSid(Sid: PSID) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlIsValidProcessTrustLabelSid(Sid: PSID) -> BOOLEAN;
+    pub fn RtlIsValidProcessTrustLabelSid(Sid: PSID) -> bool;
 }
 
 #[repr(i32)]
@@ -5874,7 +5874,7 @@ extern "system" {
 extern "system" {
     pub fn RtlAppxIsFileOwnedByTrustedInstaller(
         FileHandle: HANDLE,
-        IsFileOwnedByTrustedInstaller: *mut BOOLEAN,
+        IsFileOwnedByTrustedInstaller: *mut bool,
     ) -> NTSTATUS;
 }
 
@@ -5926,7 +5926,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlIsEnclaveFeaturePresent(FeatureMask: u32) -> BOOLEAN;
+    pub fn RtlIsEnclaveFeaturePresent(FeatureMask: u32) -> bool;
 }
 
 #[repr(i32)]
@@ -5994,12 +5994,12 @@ impl std::fmt::Debug for RTL_BSD_DATA_POWER_TRANSITION_1 {
 
 impl RTL_BSD_DATA_POWER_TRANSITION_1 {
     #[inline]
-    pub fn SystemRunning(&self) -> BOOLEAN {
+    pub fn SystemRunning(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_SystemRunning(&mut self, val: BOOLEAN) {
+    pub fn set_SystemRunning(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -6008,12 +6008,12 @@ impl RTL_BSD_DATA_POWER_TRANSITION_1 {
     }
 
     #[inline]
-    pub fn ConnectedStandbyInProgress(&self) -> BOOLEAN {
+    pub fn ConnectedStandbyInProgress(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_ConnectedStandbyInProgress(&mut self, val: BOOLEAN) {
+    pub fn set_ConnectedStandbyInProgress(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -6022,12 +6022,12 @@ impl RTL_BSD_DATA_POWER_TRANSITION_1 {
     }
 
     #[inline]
-    pub fn UserShutdownInProgress(&self) -> BOOLEAN {
+    pub fn UserShutdownInProgress(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_UserShutdownInProgress(&mut self, val: BOOLEAN) {
+    pub fn set_UserShutdownInProgress(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -6036,12 +6036,12 @@ impl RTL_BSD_DATA_POWER_TRANSITION_1 {
     }
 
     #[inline]
-    pub fn SystemShutdownInProgress(&self) -> BOOLEAN {
+    pub fn SystemShutdownInProgress(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_SystemShutdownInProgress(&mut self, val: BOOLEAN) {
+    pub fn set_SystemShutdownInProgress(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -6050,12 +6050,12 @@ impl RTL_BSD_DATA_POWER_TRANSITION_1 {
     }
 
     #[inline]
-    pub fn SleepInProgress(&self) -> BOOLEAN {
+    pub fn SleepInProgress(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(4usize, 4u8) as u8) }
     }
 
     #[inline]
-    pub fn set_SleepInProgress(&mut self, val: BOOLEAN) {
+    pub fn set_SleepInProgress(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -6065,11 +6065,11 @@ impl RTL_BSD_DATA_POWER_TRANSITION_1 {
 
     #[inline]
     pub fn new_bitfield_1(
-        SystemRunning: BOOLEAN,
-        ConnectedStandbyInProgress: BOOLEAN,
-        UserShutdownInProgress: BOOLEAN,
-        SystemShutdownInProgress: BOOLEAN,
-        SleepInProgress: BOOLEAN,
+        SystemRunning: bool,
+        ConnectedStandbyInProgress: bool,
+        UserShutdownInProgress: bool,
+        SystemShutdownInProgress: bool,
+        SleepInProgress: bool,
     ) -> BitfieldUnit<[u8; 1]> {
         let mut bitfield_unit: BitfieldUnit<[u8; 1]> = Default::default();
 
@@ -6273,7 +6273,7 @@ extern "system" {
 extern "system" {
     pub fn RtlGetSetBootStatusData(
         FileHandle: HANDLE,
-        Read: BOOLEAN,
+        Read: bool,
         DataClass: RTL_BSD_ITEM_TYPE,
         Buffer: *mut std::ffi::c_void,
         BufferSize: u32,
@@ -6283,7 +6283,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlCheckBootStatusIntegrity(FileHandle: HANDLE, Verified: *mut BOOLEAN) -> NTSTATUS;
+    pub fn RtlCheckBootStatusIntegrity(FileHandle: HANDLE, Verified: *mut bool) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -6318,12 +6318,12 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlCheckPortableOperatingSystem(IsPortable: *mut BOOLEAN) -> NTSTATUS;
+    pub fn RtlCheckPortableOperatingSystem(IsPortable: *mut bool) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlSetPortableOperatingSystem(IsPortable: BOOLEAN) -> NTSTATUS;
+    pub fn RtlSetPortableOperatingSystem(IsPortable: bool) -> NTSTATUS;
 }
 
 pub type PRTL_SECURE_MEMORY_CACHE_CALLBACK = std::option::Option<
@@ -6349,7 +6349,7 @@ extern "system" {
     pub fn RtlFlushSecureMemoryCache(
         MemoryCache: *mut std::ffi::c_void,
         MemoryLength: usize,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[repr(C)]
@@ -6637,7 +6637,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn RtlEqualWnfChangeStamps(ChangeStamp1: u32, ChangeStamp2: u32) -> BOOLEAN;
+    pub fn RtlEqualWnfChangeStamps(ChangeStamp1: u32, ChangeStamp2: u32) -> bool;
 }
 
 pub type PWNF_USER_CALLBACK = std::option::Option<

--- a/src/ntrtl.rs
+++ b/src/ntrtl.rs
@@ -1347,7 +1347,7 @@ extern "system" {
 }
 
 pub type PRTLP_UNHANDLED_EXCEPTION_FILTER =
-    std::option::Option<unsafe extern "system" fn(ExceptionInfo: *mut EXCEPTION_POINTERS) -> u32>;
+    Option<unsafe extern "system" fn(ExceptionInfo: *mut EXCEPTION_POINTERS) -> u32>;
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
@@ -2423,7 +2423,7 @@ extern "system" {
     pub fn RtlGetProcessHeaps(NumberOfHeaps: u32, ProcessHeaps: *mut *mut std::ffi::c_void) -> u32;
 }
 
-pub type PRTL_ENUM_HEAPS_ROUTINE = std::option::Option<
+pub type PRTL_ENUM_HEAPS_ROUTINE = Option<
     unsafe extern "system" fn(arg1: *mut std::ffi::c_void, arg2: *mut std::ffi::c_void) -> NTSTATUS,
 >;
 
@@ -2855,7 +2855,7 @@ impl std::fmt::Debug for HEAP_INFORMATION_ITEM {
     }
 }
 
-pub type PRTL_HEAP_EXTENDED_ENUMERATION_ROUTINE = std::option::Option<
+pub type PRTL_HEAP_EXTENDED_ENUMERATION_ROUTINE = Option<
     unsafe extern "system" fn(
         arg1: *mut HEAP_INFORMATION_ITEM,
         arg2: *mut std::ffi::c_void,
@@ -2907,7 +2907,7 @@ impl std::fmt::Debug for HEAP_EXTENDED_INFORMATION {
     }
 }
 
-pub type RTL_HEAP_STACK_WRITE_ROUTINE = std::option::Option<
+pub type RTL_HEAP_STACK_WRITE_ROUTINE = Option<
     unsafe extern "system" fn(
         Information: *mut std::ffi::c_void,
         Size: u32,
@@ -3040,7 +3040,7 @@ impl std::fmt::Debug for RTL_HEAP_STACK_CONTROL {
     }
 }
 
-pub type PRTL_HEAP_DEBUGGING_INTERCEPTOR_ROUTINE = std::option::Option<
+pub type PRTL_HEAP_DEBUGGING_INTERCEPTOR_ROUTINE = Option<
     unsafe extern "system" fn(
         HeapHandle: *mut std::ffi::c_void,
         Action: u32,
@@ -3049,7 +3049,7 @@ pub type PRTL_HEAP_DEBUGGING_INTERCEPTOR_ROUTINE = std::option::Option<
     ) -> NTSTATUS,
 >;
 
-pub type PRTL_HEAP_LEAK_ENUMERATION_ROUTINE = std::option::Option<
+pub type PRTL_HEAP_LEAK_ENUMERATION_ROUTINE = Option<
     unsafe extern "system" fn(
         Reserved: i32,
         HeapHandle: *mut std::ffi::c_void,
@@ -4635,7 +4635,7 @@ extern "system" {
     ) -> NTSTATUS;
 }
 
-pub type PRTL_START_POOL_THREAD = std::option::Option<
+pub type PRTL_START_POOL_THREAD = Option<
     unsafe extern "system" fn(
         arg1: LPTHREAD_START_ROUTINE,
         arg2: *mut std::ffi::c_void,
@@ -4644,7 +4644,7 @@ pub type PRTL_START_POOL_THREAD = std::option::Option<
 >;
 
 pub type PRTL_EXIT_POOL_THREAD =
-    std::option::Option<unsafe extern "system" fn(arg1: NTSTATUS) -> NTSTATUS>;
+    Option<unsafe extern "system" fn(arg1: NTSTATUS) -> NTSTATUS>;
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
@@ -6000,11 +6000,7 @@ impl RTL_BSD_DATA_POWER_TRANSITION_1 {
 
     #[inline]
     pub fn set_SystemRunning(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(0usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -6014,11 +6010,7 @@ impl RTL_BSD_DATA_POWER_TRANSITION_1 {
 
     #[inline]
     pub fn set_ConnectedStandbyInProgress(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(1usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(1usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -6028,11 +6020,7 @@ impl RTL_BSD_DATA_POWER_TRANSITION_1 {
 
     #[inline]
     pub fn set_UserShutdownInProgress(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(2usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(2usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -6042,11 +6030,7 @@ impl RTL_BSD_DATA_POWER_TRANSITION_1 {
 
     #[inline]
     pub fn set_SystemShutdownInProgress(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(3usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(3usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -6056,11 +6040,7 @@ impl RTL_BSD_DATA_POWER_TRANSITION_1 {
 
     #[inline]
     pub fn set_SleepInProgress(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(4usize, 4u8, val as u64)
-        }
+        self._bitfield_1.set(4usize, 4u8, val as u64)
     }
 
     #[inline]
@@ -6074,34 +6054,22 @@ impl RTL_BSD_DATA_POWER_TRANSITION_1 {
         let mut bitfield_unit: BitfieldUnit<[u8; 1]> = Default::default();
 
         bitfield_unit.set(0usize, 1u8, {
-            let SystemRunning: u8 = unsafe { std::mem::transmute(SystemRunning) };
-
             SystemRunning as u64
         });
 
         bitfield_unit.set(1usize, 1u8, {
-            let ConnectedStandbyInProgress: u8 =
-                unsafe { std::mem::transmute(ConnectedStandbyInProgress) };
-
             ConnectedStandbyInProgress as u64
         });
 
         bitfield_unit.set(2usize, 1u8, {
-            let UserShutdownInProgress: u8 = unsafe { std::mem::transmute(UserShutdownInProgress) };
-
             UserShutdownInProgress as u64
         });
 
         bitfield_unit.set(3usize, 1u8, {
-            let SystemShutdownInProgress: u8 =
-                unsafe { std::mem::transmute(SystemShutdownInProgress) };
-
             SystemShutdownInProgress as u64
         });
 
         bitfield_unit.set(4usize, 4u8, {
-            let SleepInProgress: u8 = unsafe { std::mem::transmute(SleepInProgress) };
-
             SleepInProgress as u64
         });
 
@@ -6326,7 +6294,7 @@ extern "system" {
     pub fn RtlSetPortableOperatingSystem(IsPortable: bool) -> NTSTATUS;
 }
 
-pub type PRTL_SECURE_MEMORY_CACHE_CALLBACK = std::option::Option<
+pub type PRTL_SECURE_MEMORY_CACHE_CALLBACK = Option<
     unsafe extern "system" fn(arg1: *mut std::ffi::c_void, arg2: usize) -> NTSTATUS,
 >;
 
@@ -6600,7 +6568,7 @@ extern "system" {
 }
 
 pub type PRTL_FEATURE_CONFIGURATION_CHANGE_NOTIFICATION =
-    std::option::Option<unsafe extern "system" fn(arg1: *mut std::ffi::c_void)>;
+    Option<unsafe extern "system" fn(arg1: *mut std::ffi::c_void)>;
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
@@ -6640,7 +6608,7 @@ extern "system" {
     pub fn RtlEqualWnfChangeStamps(ChangeStamp1: u32, ChangeStamp2: u32) -> bool;
 }
 
-pub type PWNF_USER_CALLBACK = std::option::Option<
+pub type PWNF_USER_CALLBACK = Option<
     unsafe extern "system" fn(
         arg1: WNF_STATE_NAME,
         arg2: u32,

--- a/src/ntsam.rs
+++ b/src/ntsam.rs
@@ -2,7 +2,7 @@ use windows::{
     core::PWSTR,
     Wdk::Foundation::OBJECT_ATTRIBUTES,
     Win32::{
-        Foundation::{BOOL, BOOLEAN, HANDLE, NTSTATUS, UNICODE_STRING},
+        Foundation::{HANDLE, NTSTATUS, UNICODE_STRING},
         Security::{
             Authentication::Identity::{
                 DOMAIN_PASSWORD_INFORMATION, LOGON_HOURS, USER_ALL_INFORMATION,
@@ -297,7 +297,7 @@ extern "system" {
         ObjectAttributes: *mut OBJECT_ATTRIBUTES,
         Creds: *mut std::ffi::c_void,
         Spn: PWSTR,
-        pfDstIsW2K: *mut BOOL,
+        pfDstIsW2K: *mut bool,
     ) -> NTSTATUS;
 }
 
@@ -347,7 +347,7 @@ pub struct DOMAIN_GENERAL_INFORMATION {
     pub DomainModifiedCount: i64,
     pub DomainServerState: DOMAIN_SERVER_ENABLE_STATE,
     pub DomainServerRole: DOMAIN_SERVER_ROLE,
-    pub UasCompatibilityRequired: BOOLEAN,
+    pub UasCompatibilityRequired: bool,
     pub UserCount: u32,
     pub GroupCount: u32,
     pub AliasCount: u32,
@@ -391,7 +391,7 @@ impl std::fmt::Debug for DOMAIN_GENERAL_INFORMATION2 {
 
 #[repr(C)]
 pub struct DOMAIN_UAS_INFORMATION {
-    pub UasCompatibilityRequired: BOOLEAN,
+    pub UasCompatibilityRequired: bool,
 }
 
 impl Default for DOMAIN_UAS_INFORMATION {
@@ -1539,7 +1539,7 @@ impl std::fmt::Debug for USER_WORKSTATIONS_INFORMATION {
 #[repr(C)]
 pub struct USER_SET_PASSWORD_INFORMATION {
     pub Password: UNICODE_STRING,
-    pub PasswordExpired: BOOLEAN,
+    pub PasswordExpired: bool,
 }
 
 impl Default for USER_SET_PASSWORD_INFORMATION {
@@ -1609,9 +1609,9 @@ impl std::fmt::Debug for ENCRYPTED_NT_OWF_PASSWORD {
 pub struct USER_INTERNAL1_INFORMATION {
     pub EncryptedNtOwfPassword: ENCRYPTED_NT_OWF_PASSWORD,
     pub EncryptedLmOwfPassword: ENCRYPTED_LM_OWF_PASSWORD,
-    pub NtPasswordPresent: BOOLEAN,
-    pub LmPasswordPresent: BOOLEAN,
-    pub PasswordExpired: BOOLEAN,
+    pub NtPasswordPresent: bool,
+    pub LmPasswordPresent: bool,
+    pub PasswordExpired: bool,
 }
 
 impl Default for USER_INTERNAL1_INFORMATION {
@@ -1728,7 +1728,7 @@ impl std::fmt::Debug for USER_INTERNAL4_INFORMATION {
 #[repr(C)]
 pub struct USER_INTERNAL5_INFORMATION {
     pub UserPassword: ENCRYPTED_USER_PASSWORD,
-    pub PasswordExpired: BOOLEAN,
+    pub PasswordExpired: bool,
 }
 
 impl Default for USER_INTERNAL5_INFORMATION {
@@ -1793,7 +1793,7 @@ impl std::fmt::Debug for USER_INTERNAL4_INFORMATION_NEW {
 #[repr(C)]
 pub struct USER_INTERNAL5_INFORMATION_NEW {
     pub UserPassword: ENCRYPTED_USER_PASSWORD_NEW,
-    pub PasswordExpired: BOOLEAN,
+    pub PasswordExpired: bool,
 }
 
 impl Default for USER_INTERNAL5_INFORMATION_NEW {
@@ -1840,7 +1840,7 @@ pub struct USER_INTERNAL6_INFORMATION {
     pub I1: USER_ALL_INFORMATION,
     pub LastBadPasswordTime: i64,
     pub ExtendedFields: u32,
-    pub UPNDefaulted: BOOLEAN,
+    pub UPNDefaulted: bool,
     pub UPN: UNICODE_STRING,
     pub A2D2List: *mut USER_ALLOWED_TO_DELEGATE_TO_LIST,
 }
@@ -1870,7 +1870,7 @@ pub struct USER_EXTENDED_INFORMATION {
     pub ExtendedWhichFields: u32,
     pub UserTile: SAM_USER_TILE,
     pub PasswordHint: UNICODE_STRING,
-    pub DontShowInLogonUI: BOOLEAN,
+    pub DontShowInLogonUI: bool,
     pub ShellAdminObjectProperties: SAM_SHELL_OBJECT_PROPERTIES,
 }
 
@@ -1892,8 +1892,8 @@ impl std::fmt::Debug for USER_EXTENDED_INFORMATION {
 
 #[repr(C)]
 pub struct USER_LOGON_UI_INFORMATION {
-    pub PasswordIsBlank: BOOLEAN,
-    pub AccountIsDisabled: BOOLEAN,
+    pub PasswordIsBlank: bool,
+    pub AccountIsDisabled: bool,
 }
 
 impl Default for USER_LOGON_UI_INFORMATION {
@@ -1936,7 +1936,7 @@ impl std::fmt::Debug for ENCRYPTED_PASSWORD_AES {
 #[repr(C)]
 pub struct USER_INTERNAL7_INFORMATION {
     pub UserPassword: ENCRYPTED_PASSWORD_AES,
-    pub PasswordExpired: BOOLEAN,
+    pub PasswordExpired: bool,
 }
 
 impl Default for USER_INTERNAL7_INFORMATION {
@@ -2345,7 +2345,7 @@ impl std::fmt::Debug for SAM_VALIDATE_STANDARD_OUTPUT_ARG {
 #[repr(C)]
 pub struct SAM_VALIDATE_AUTHENTICATION_INPUT_ARG {
     pub InputPersistedFields: SAM_VALIDATE_PERSISTED_FIELDS,
-    pub PasswordMatched: BOOLEAN,
+    pub PasswordMatched: bool,
 }
 
 impl Default for SAM_VALIDATE_AUTHENTICATION_INPUT_ARG {
@@ -2370,7 +2370,7 @@ pub struct SAM_VALIDATE_PASSWORD_CHANGE_INPUT_ARG {
     pub ClearPassword: UNICODE_STRING,
     pub UserAccountName: UNICODE_STRING,
     pub HashedPassword: SAM_VALIDATE_PASSWORD_HASH,
-    pub PasswordMatch: BOOLEAN,
+    pub PasswordMatch: bool,
 }
 
 impl Default for SAM_VALIDATE_PASSWORD_CHANGE_INPUT_ARG {
@@ -2395,8 +2395,8 @@ pub struct SAM_VALIDATE_PASSWORD_RESET_INPUT_ARG {
     pub ClearPassword: UNICODE_STRING,
     pub UserAccountName: UNICODE_STRING,
     pub HashedPassword: SAM_VALIDATE_PASSWORD_HASH,
-    pub PasswordMustChangeAtNextLogon: BOOLEAN,
-    pub ClearLockout: BOOLEAN,
+    pub PasswordMustChangeAtNextLogon: bool,
+    pub ClearLockout: bool,
 }
 
 impl Default for SAM_VALIDATE_PASSWORD_RESET_INPUT_ARG {
@@ -2473,7 +2473,7 @@ pub enum SAM_GENERIC_OPERATION_TYPE {
 
 #[repr(C)]
 pub struct SAM_OPERATION_OBJCHG_INPUT {
-    pub Register: BOOLEAN,
+    pub Register: bool,
     pub EventHandle: u64,
     pub ObjectType: SECURITY_DB_OBJECT_TYPE,
     pub ProcessID: u32,

--- a/src/ntseapi.rs
+++ b/src/ntseapi.rs
@@ -1,7 +1,7 @@
 use windows::{
     Wdk::Foundation::OBJECT_ATTRIBUTES,
     Win32::{
-        Foundation::{BOOLEAN, HANDLE, LUID, NTSTATUS, UNICODE_STRING},
+        Foundation::{HANDLE, LUID, NTSTATUS, UNICODE_STRING},
         Security::{
             GENERIC_MAPPING, OBJECT_TYPE_LIST, PRIVILEGE_SET, PSID, SECURITY_DESCRIPTOR,
             SID_AND_ATTRIBUTES, TOKEN_DEFAULT_DACL, TOKEN_GROUPS, TOKEN_MANDATORY_POLICY,
@@ -261,9 +261,9 @@ extern "system" {
 extern "system" {
     pub fn NtAdjustTokenClaimsAndDeviceGroups(
         TokenHandle: HANDLE,
-        UserResetToDefault: BOOLEAN,
-        DeviceResetToDefault: BOOLEAN,
-        DeviceGroupsResetToDefault: BOOLEAN,
+        UserResetToDefault: bool,
+        DeviceResetToDefault: bool,
+        DeviceGroupsResetToDefault: bool,
         NewUserState: *mut TOKEN_SECURITY_ATTRIBUTES_INFORMATION,
         NewDeviceState: *mut TOKEN_SECURITY_ATTRIBUTES_INFORMATION,
         NewDeviceGroupsState: *mut TOKEN_GROUPS,
@@ -304,7 +304,7 @@ extern "system" {
     pub fn NtCompareTokens(
         FirstTokenHandle: HANDLE,
         SecondTokenHandle: HANDLE,
-        Equal: *mut BOOLEAN,
+        Equal: *mut bool,
     ) -> NTSTATUS;
 }
 

--- a/src/ntsxs.rs
+++ b/src/ntsxs.rs
@@ -1,7 +1,7 @@
 use windows::{
     core::GUID,
     Win32::{
-        Foundation::{BOOLEAN, HANDLE, UNICODE_STRING},
+        Foundation::{HANDLE, UNICODE_STRING},
         System::{
             ApplicationInstallationAndServicing::{
                 ACTCTX_COMPATIBILITY_ELEMENT_TYPE, ACTCTX_REQUESTED_RUN_LEVEL,
@@ -828,7 +828,7 @@ pub type PACTIVATION_CONTEXT_NOTIFY_ROUTINE = std::option::Option<
         ActivationContextData: *mut ACTIVATION_CONTEXT_DATA,
         NotificationContext: *mut std::ffi::c_void,
         NotificationData: *mut std::ffi::c_void,
-        DisableThisNotification: *mut BOOLEAN,
+        DisableThisNotification: *mut bool,
     ),
 >;
 

--- a/src/ntwow64.rs
+++ b/src/ntwow64.rs
@@ -1036,11 +1036,7 @@ impl PEB32_1_1 {
 
     #[inline]
     pub fn set_ImageUsesLargePages(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(0usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -1050,11 +1046,7 @@ impl PEB32_1_1 {
 
     #[inline]
     pub fn set_IsProtectedProcess(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(1usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(1usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -1064,11 +1056,7 @@ impl PEB32_1_1 {
 
     #[inline]
     pub fn set_IsImageDynamicallyRelocated(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(2usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(2usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -1078,11 +1066,7 @@ impl PEB32_1_1 {
 
     #[inline]
     pub fn set_SkipPatchingUser32Forwarders(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(3usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(3usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -1092,11 +1076,7 @@ impl PEB32_1_1 {
 
     #[inline]
     pub fn set_IsPackagedProcess(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(4usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(4usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -1106,11 +1086,7 @@ impl PEB32_1_1 {
 
     #[inline]
     pub fn set_IsAppContainer(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(5usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(5usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -1120,11 +1096,7 @@ impl PEB32_1_1 {
 
     #[inline]
     pub fn set_IsProtectedProcessLight(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(6usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(6usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -1134,11 +1106,7 @@ impl PEB32_1_1 {
 
     #[inline]
     pub fn set_IsLongPathAwareProcess(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = std::mem::transmute(val);
-
-            self._bitfield_1.set(7usize, 1u8, val as u64)
-        }
+        self._bitfield_1.set(7usize, 1u8, val as u64)
     }
 
     #[inline]
@@ -1155,53 +1123,34 @@ impl PEB32_1_1 {
         let mut bitfield_unit: BitfieldUnit<[u8; 1]> = Default::default();
 
         bitfield_unit.set(0usize, 1u8, {
-            let ImageUsesLargePages: u8 = unsafe { std::mem::transmute(ImageUsesLargePages) };
-
             ImageUsesLargePages as u64
         });
 
         bitfield_unit.set(1usize, 1u8, {
-            let IsProtectedProcess: u8 = unsafe { std::mem::transmute(IsProtectedProcess) };
-
             IsProtectedProcess as u64
         });
 
         bitfield_unit.set(2usize, 1u8, {
-            let IsImageDynamicallyRelocated: u8 =
-                unsafe { std::mem::transmute(IsImageDynamicallyRelocated) };
-
             IsImageDynamicallyRelocated as u64
         });
 
         bitfield_unit.set(3usize, 1u8, {
-            let SkipPatchingUser32Forwarders: u8 =
-                unsafe { std::mem::transmute(SkipPatchingUser32Forwarders) };
-
             SkipPatchingUser32Forwarders as u64
         });
 
         bitfield_unit.set(4usize, 1u8, {
-            let IsPackagedProcess: u8 = unsafe { std::mem::transmute(IsPackagedProcess) };
-
             IsPackagedProcess as u64
         });
 
         bitfield_unit.set(5usize, 1u8, {
-            let IsAppContainer: u8 = unsafe { std::mem::transmute(IsAppContainer) };
-
             IsAppContainer as u64
         });
 
         bitfield_unit.set(6usize, 1u8, {
-            let IsProtectedProcessLight: u8 =
-                unsafe { std::mem::transmute(IsProtectedProcessLight) };
-
             IsProtectedProcessLight as u64
         });
 
         bitfield_unit.set(7usize, 1u8, {
-            let IsLongPathAwareProcess: u8 = unsafe { std::mem::transmute(IsLongPathAwareProcess) };
-
             IsLongPathAwareProcess as u64
         });
 

--- a/src/ntwow64.rs
+++ b/src/ntwow64.rs
@@ -1,7 +1,7 @@
 use windows::{
     core::GUID,
     Win32::{
-        Foundation::{BOOLEAN, NTSTATUS},
+        Foundation::{NTSTATUS},
         System::{
             Kernel::{LIST_ENTRY32, PROCESSOR_NUMBER, SINGLE_LIST_ENTRY32, STRING32},
             SystemServices::NT_TIB32,
@@ -178,13 +178,13 @@ impl std::fmt::Debug for RTL_RB_TREE32 {
 #[repr(C)]
 pub struct PEB_LDR_DATA32 {
     pub Length: u32,
-    pub Initialized: BOOLEAN,
+    pub Initialized: bool,
     pub SsHandle: u32,
     pub InLoadOrderModuleList: LIST_ENTRY32,
     pub InMemoryOrderModuleList: LIST_ENTRY32,
     pub InInitializationOrderModuleList: LIST_ENTRY32,
     pub EntryInProgress: u32,
-    pub ShutdownInProgress: BOOLEAN,
+    pub ShutdownInProgress: bool,
     pub ShutdownThreadId: u32,
 }
 
@@ -898,9 +898,9 @@ impl std::fmt::Debug for RTL_USER_PROCESS_PARAMETERS32 {
 
 #[repr(C)]
 pub struct PEB32 {
-    pub InheritedAddressSpace: BOOLEAN,
-    pub ReadImageFileExecOptions: BOOLEAN,
-    pub BeingDebugged: BOOLEAN,
+    pub InheritedAddressSpace: bool,
+    pub ReadImageFileExecOptions: bool,
+    pub BeingDebugged: bool,
     pub Anonymous1: PEB32_1,
     pub Mutant: u32,
     pub ImageBaseAddress: u32,
@@ -994,7 +994,7 @@ pub struct PEB32 {
 
 #[repr(C)]
 pub struct PEB32_1 {
-    pub BitField: UnionField<BOOLEAN>,
+    pub BitField: UnionField<bool>,
     pub Anonymous1: UnionField<PEB32_1_1>,
     pub union_field: u8,
 }
@@ -1030,12 +1030,12 @@ impl std::fmt::Debug for PEB32_1_1 {
 
 impl PEB32_1_1 {
     #[inline]
-    pub fn ImageUsesLargePages(&self) -> BOOLEAN {
+    pub fn ImageUsesLargePages(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_ImageUsesLargePages(&mut self, val: BOOLEAN) {
+    pub fn set_ImageUsesLargePages(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -1044,12 +1044,12 @@ impl PEB32_1_1 {
     }
 
     #[inline]
-    pub fn IsProtectedProcess(&self) -> BOOLEAN {
+    pub fn IsProtectedProcess(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_IsProtectedProcess(&mut self, val: BOOLEAN) {
+    pub fn set_IsProtectedProcess(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -1058,12 +1058,12 @@ impl PEB32_1_1 {
     }
 
     #[inline]
-    pub fn IsImageDynamicallyRelocated(&self) -> BOOLEAN {
+    pub fn IsImageDynamicallyRelocated(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_IsImageDynamicallyRelocated(&mut self, val: BOOLEAN) {
+    pub fn set_IsImageDynamicallyRelocated(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -1072,12 +1072,12 @@ impl PEB32_1_1 {
     }
 
     #[inline]
-    pub fn SkipPatchingUser32Forwarders(&self) -> BOOLEAN {
+    pub fn SkipPatchingUser32Forwarders(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_SkipPatchingUser32Forwarders(&mut self, val: BOOLEAN) {
+    pub fn set_SkipPatchingUser32Forwarders(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -1086,12 +1086,12 @@ impl PEB32_1_1 {
     }
 
     #[inline]
-    pub fn IsPackagedProcess(&self) -> BOOLEAN {
+    pub fn IsPackagedProcess(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_IsPackagedProcess(&mut self, val: BOOLEAN) {
+    pub fn set_IsPackagedProcess(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -1100,12 +1100,12 @@ impl PEB32_1_1 {
     }
 
     #[inline]
-    pub fn IsAppContainer(&self) -> BOOLEAN {
+    pub fn IsAppContainer(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_IsAppContainer(&mut self, val: BOOLEAN) {
+    pub fn set_IsAppContainer(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -1114,12 +1114,12 @@ impl PEB32_1_1 {
     }
 
     #[inline]
-    pub fn IsProtectedProcessLight(&self) -> BOOLEAN {
+    pub fn IsProtectedProcessLight(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(6usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_IsProtectedProcessLight(&mut self, val: BOOLEAN) {
+    pub fn set_IsProtectedProcessLight(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -1128,12 +1128,12 @@ impl PEB32_1_1 {
     }
 
     #[inline]
-    pub fn IsLongPathAwareProcess(&self) -> BOOLEAN {
+    pub fn IsLongPathAwareProcess(&self) -> bool {
         unsafe { std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u8) }
     }
 
     #[inline]
-    pub fn set_IsLongPathAwareProcess(&mut self, val: BOOLEAN) {
+    pub fn set_IsLongPathAwareProcess(&mut self, val: bool) {
         unsafe {
             let val: u8 = std::mem::transmute(val);
 
@@ -1143,14 +1143,14 @@ impl PEB32_1_1 {
 
     #[inline]
     pub fn new_bitfield_1(
-        ImageUsesLargePages: BOOLEAN,
-        IsProtectedProcess: BOOLEAN,
-        IsImageDynamicallyRelocated: BOOLEAN,
-        SkipPatchingUser32Forwarders: BOOLEAN,
-        IsPackagedProcess: BOOLEAN,
-        IsAppContainer: BOOLEAN,
-        IsProtectedProcessLight: BOOLEAN,
-        IsLongPathAwareProcess: BOOLEAN,
+        ImageUsesLargePages: bool,
+        IsProtectedProcess: bool,
+        IsImageDynamicallyRelocated: bool,
+        SkipPatchingUser32Forwarders: bool,
+        IsPackagedProcess: bool,
+        IsAppContainer: bool,
+        IsProtectedProcessLight: bool,
+        IsLongPathAwareProcess: bool,
     ) -> BitfieldUnit<[u8; 1]> {
         let mut bitfield_unit: BitfieldUnit<[u8; 1]> = Default::default();
 
@@ -1649,7 +1649,7 @@ pub struct TEB32 {
     pub InstrumentationCallbackSp: u32,
     pub InstrumentationCallbackPreviousPc: u32,
     pub InstrumentationCallbackPreviousSp: u32,
-    pub InstrumentationCallbackDisabled: BOOLEAN,
+    pub InstrumentationCallbackDisabled: bool,
     pub SpareBytes: [u8; 23],
     pub TxFsContext: u32,
     pub GdiTebBatch: GDI_TEB_BATCH32,

--- a/src/ntxcapi.rs
+++ b/src/ntxcapi.rs
@@ -1,5 +1,5 @@
 use windows::Win32::{
-    Foundation::{BOOLEAN, NTSTATUS},
+    Foundation::NTSTATUS,
     System::Diagnostics::Debug::{CONTEXT, EXCEPTION_RECORD},
 };
 
@@ -11,7 +11,7 @@ extern "system" {
     pub fn RtlDispatchException(
         ExceptionRecord: *mut EXCEPTION_RECORD,
         ContextRecord: *mut CONTEXT,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -21,7 +21,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn NtContinue(ContextRecord: *mut CONTEXT, TestAlert: BOOLEAN) -> NTSTATUS;
+    pub fn NtContinue(ContextRecord: *mut CONTEXT, TestAlert: bool) -> NTSTATUS;
 }
 
 #[repr(i32)]
@@ -70,6 +70,6 @@ extern "system" {
     pub fn NtRaiseException(
         ExceptionRecord: *mut EXCEPTION_RECORD,
         ContextRecord: *mut CONTEXT,
-        FirstChance: BOOLEAN,
+        FirstChance: bool,
     ) -> NTSTATUS;
 }

--- a/src/ntzwapi.rs
+++ b/src/ntzwapi.rs
@@ -13,7 +13,7 @@ use windows::{
         },
     },
     Win32::{
-        Foundation::{BOOLEAN, HANDLE, LUID, NTSTATUS, UNICODE_STRING},
+        Foundation::{HANDLE, LUID, NTSTATUS, UNICODE_STRING},
         Security::{
             AUDIT_EVENT_TYPE, GENERIC_MAPPING, OBJECT_TYPE_LIST, PRIVILEGE_SET, PSID,
             SECURITY_DESCRIPTOR, SECURITY_QUALITY_OF_SERVICE, SID_AND_ATTRIBUTES,
@@ -71,7 +71,7 @@ extern "system" {
         PortHandle: *mut HANDLE,
         PortContext: *mut std::ffi::c_void,
         ConnectionRequest: *mut PORT_MESSAGE,
-        AcceptConnection: BOOLEAN,
+        AcceptConnection: bool,
         ServerView: *mut PORT_VIEW,
         ClientView: *mut REMOTE_PORT_VIEW,
     ) -> NTSTATUS;
@@ -101,10 +101,10 @@ extern "system" {
         SecurityDescriptor: *mut SECURITY_DESCRIPTOR,
         DesiredAccess: u32,
         GenericMapping: *mut GENERIC_MAPPING,
-        ObjectCreation: BOOLEAN,
+        ObjectCreation: bool,
         GrantedAccess: *mut u32,
         AccessStatus: *mut NTSTATUS,
-        GenerateOnClose: *mut BOOLEAN,
+        GenerateOnClose: *mut bool,
     ) -> NTSTATUS;
 }
 
@@ -140,10 +140,10 @@ extern "system" {
         ObjectTypeList: *mut OBJECT_TYPE_LIST,
         ObjectTypeListLength: u32,
         GenericMapping: *mut GENERIC_MAPPING,
-        ObjectCreation: BOOLEAN,
+        ObjectCreation: bool,
         GrantedAccess: *mut u32,
         AccessStatus: *mut NTSTATUS,
-        GenerateOnClose: *mut BOOLEAN,
+        GenerateOnClose: *mut bool,
     ) -> NTSTATUS;
 }
 
@@ -179,10 +179,10 @@ extern "system" {
         ObjectTypeList: *mut OBJECT_TYPE_LIST,
         ObjectTypeListLength: u32,
         GenericMapping: *mut GENERIC_MAPPING,
-        ObjectCreation: BOOLEAN,
+        ObjectCreation: bool,
         GrantedAccess: *mut u32,
         AccessStatus: *mut NTSTATUS,
-        GenerateOnClose: *mut BOOLEAN,
+        GenerateOnClose: *mut bool,
     ) -> NTSTATUS;
 }
 
@@ -202,10 +202,10 @@ extern "system" {
         ObjectTypeList: *mut OBJECT_TYPE_LIST,
         ObjectTypeListLength: u32,
         GenericMapping: *mut GENERIC_MAPPING,
-        ObjectCreation: BOOLEAN,
+        ObjectCreation: bool,
         GrantedAccess: *mut u32,
         AccessStatus: *mut NTSTATUS,
-        GenerateOnClose: *mut BOOLEAN,
+        GenerateOnClose: *mut bool,
     ) -> NTSTATUS;
 }
 
@@ -213,8 +213,8 @@ extern "system" {
 extern "system" {
     pub fn ZwAcquireCMFViewOwnership(
         TimeStamp: *mut u64,
-        tokenTaken: *mut BOOLEAN,
-        replaceExisting: BOOLEAN,
+        tokenTaken: *mut bool,
+        replaceExisting: bool,
     ) -> NTSTATUS;
 }
 
@@ -242,7 +242,7 @@ extern "system" {
 extern "system" {
     pub fn ZwAdjustGroupsToken(
         TokenHandle: HANDLE,
-        ResetToDefault: BOOLEAN,
+        ResetToDefault: bool,
         NewState: *mut TOKEN_GROUPS,
         BufferLength: u32,
         PreviousState: *mut TOKEN_GROUPS,
@@ -254,7 +254,7 @@ extern "system" {
 extern "system" {
     pub fn ZwAdjustPrivilegesToken(
         TokenHandle: HANDLE,
-        DisableAllPrivileges: BOOLEAN,
+        DisableAllPrivileges: bool,
         NewState: *mut TOKEN_PRIVILEGES,
         BufferLength: u32,
         PreviousState: *mut TOKEN_PRIVILEGES,
@@ -266,9 +266,9 @@ extern "system" {
 extern "system" {
     pub fn ZwAdjustTokenClaimsAndDeviceGroups(
         TokenHandle: HANDLE,
-        UserResetToDefault: BOOLEAN,
-        DeviceResetToDefault: BOOLEAN,
-        DeviceGroupsResetToDefault: BOOLEAN,
+        UserResetToDefault: bool,
+        DeviceResetToDefault: bool,
+        DeviceGroupsResetToDefault: bool,
         NewUserState: *mut TOKEN_SECURITY_ATTRIBUTES_INFORMATION,
         NewDeviceState: *mut TOKEN_SECURITY_ATTRIBUTES_INFORMATION,
         NewDeviceGroupsState: *mut TOKEN_GROUPS,
@@ -349,7 +349,7 @@ extern "system" {
         PortContext: *mut std::ffi::c_void,
         ConnectionRequest: *mut PORT_MESSAGE,
         ConnectionMessageAttributes: *mut ALPC_MESSAGE_ATTRIBUTES,
-        AcceptConnection: BOOLEAN,
+        AcceptConnection: bool,
     ) -> NTSTATUS;
 }
 
@@ -607,7 +607,7 @@ extern "system" {
         ApcContext: *mut std::ffi::c_void,
         IoStatus: NTSTATUS,
         IoStatusInformation: usize,
-        AlreadySignaled: *mut BOOLEAN,
+        AlreadySignaled: *mut bool,
     ) -> NTSTATUS;
 }
 
@@ -625,7 +625,7 @@ extern "system" {
     pub fn ZwCallEnclave(
         Routine: PENCLAVE_ROUTINE,
         Parameter: *mut std::ffi::c_void,
-        WaitForThread: BOOLEAN,
+        WaitForThread: bool,
         ReturnValue: *mut *mut std::ffi::c_void,
     ) -> NTSTATUS;
 }
@@ -662,7 +662,7 @@ extern "system" {
 extern "system" {
     pub fn ZwCancelWaitCompletionPacket(
         WaitCompletionPacketHandle: HANDLE,
-        RemoveSignaledPacket: BOOLEAN,
+        RemoveSignaledPacket: bool,
     ) -> NTSTATUS;
 }
 
@@ -700,7 +700,7 @@ extern "system" {
     pub fn ZwCloseObjectAuditAlarm(
         SubsystemName: *mut UNICODE_STRING,
         HandleId: *mut std::ffi::c_void,
-        GenerateOnClose: BOOLEAN,
+        GenerateOnClose: bool,
     ) -> NTSTATUS;
 }
 
@@ -724,7 +724,7 @@ extern "system" {
     pub fn ZwCompareTokens(
         FirstTokenHandle: HANDLE,
         SecondTokenHandle: HANDLE,
-        Equal: *mut BOOLEAN,
+        Equal: *mut bool,
     ) -> NTSTATUS;
 }
 
@@ -754,7 +754,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn ZwContinue(ContextRecord: *mut CONTEXT, TestAlert: BOOLEAN) -> NTSTATUS;
+    pub fn ZwContinue(ContextRecord: *mut CONTEXT, TestAlert: bool) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -884,7 +884,7 @@ extern "system" {
         MutantHandle: *mut HANDLE,
         DesiredAccess: u32,
         ObjectAttributes: *mut OBJECT_ATTRIBUTES,
-        InitialOwner: BOOLEAN,
+        InitialOwner: bool,
     ) -> NTSTATUS;
 }
 
@@ -957,7 +957,7 @@ extern "system" {
         DesiredAccess: u32,
         ObjectAttributes: *mut OBJECT_ATTRIBUTES,
         ParentProcess: HANDLE,
-        InheritObjectTable: BOOLEAN,
+        InheritObjectTable: bool,
         SectionHandle: HANDLE,
         DebugPort: HANDLE,
         TokenHandle: HANDLE,
@@ -1067,7 +1067,7 @@ extern "system" {
         ClientId: *mut CLIENT_ID,
         ThreadContext: *mut CONTEXT,
         InitialTeb: *mut INITIAL_TEB,
-        CreateSuspended: BOOLEAN,
+        CreateSuspended: bool,
     ) -> NTSTATUS;
 }
 
@@ -1195,7 +1195,7 @@ extern "system" {
         StateName: *mut WNF_STATE_NAME,
         NameLifetime: WNF_STATE_NAME_LIFETIME,
         DataScope: WNF_DATA_SCOPE,
-        PersistData: BOOLEAN,
+        PersistData: bool,
         TypeId: *const WNF_TYPE_ID,
         MaximumStateSize: u32,
         SecurityDescriptor: *mut SECURITY_DESCRIPTOR,
@@ -1234,7 +1234,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn ZwDelayExecution(Alertable: BOOLEAN, DelayInterval: *mut i64) -> NTSTATUS;
+    pub fn ZwDelayExecution(Alertable: bool, DelayInterval: *mut i64) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -1257,7 +1257,7 @@ extern "system" {
     pub fn ZwDeleteObjectAuditAlarm(
         SubsystemName: *mut UNICODE_STRING,
         HandleId: *mut std::ffi::c_void,
-        GenerateOnClose: BOOLEAN,
+        GenerateOnClose: bool,
     ) -> NTSTATUS;
 }
 
@@ -1570,7 +1570,7 @@ extern "system" {
         SystemAction: POWER_ACTION,
         LightestSystemState: SYSTEM_POWER_STATE,
         Flags: u32,
-        Asynchronous: BOOLEAN,
+        Asynchronous: bool,
     ) -> NTSTATUS;
 }
 
@@ -1581,7 +1581,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn ZwIsSystemResumeAutomatic() -> BOOLEAN;
+    pub fn ZwIsSystemResumeAutomatic() -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -1741,7 +1741,7 @@ extern "system" {
         Buffer: *mut std::ffi::c_void,
         Length: u32,
         CompletionFilter: u32,
-        WatchTree: BOOLEAN,
+        WatchTree: bool,
     ) -> NTSTATUS;
 }
 
@@ -1756,7 +1756,7 @@ extern "system" {
         Buffer: *mut std::ffi::c_void,
         Length: u32,
         CompletionFilter: u32,
-        WatchTree: BOOLEAN,
+        WatchTree: bool,
         DirectoryNotifyInformationClass: DIRECTORY_NOTIFY_INFORMATION_CLASS,
     ) -> NTSTATUS;
 }
@@ -1772,10 +1772,10 @@ extern "system" {
         ApcContext: *mut std::ffi::c_void,
         IoStatusBlock: *mut IO_STATUS_BLOCK,
         CompletionFilter: u32,
-        WatchTree: BOOLEAN,
+        WatchTree: bool,
         Buffer: *mut std::ffi::c_void,
         BufferSize: u32,
-        Asynchronous: BOOLEAN,
+        Asynchronous: bool,
     ) -> NTSTATUS;
 }
 
@@ -1850,9 +1850,9 @@ extern "system" {
         DesiredAccess: u32,
         GrantedAccess: u32,
         Privileges: *mut PRIVILEGE_SET,
-        ObjectCreation: BOOLEAN,
-        AccessGranted: BOOLEAN,
-        GenerateOnClose: *mut BOOLEAN,
+        ObjectCreation: bool,
+        AccessGranted: bool,
+        GenerateOnClose: *mut bool,
     ) -> NTSTATUS;
 }
 
@@ -1908,7 +1908,7 @@ extern "system" {
     pub fn ZwOpenThreadToken(
         ThreadHandle: HANDLE,
         DesiredAccess: u32,
-        OpenAsSelf: BOOLEAN,
+        OpenAsSelf: bool,
         TokenHandle: *mut HANDLE,
     ) -> NTSTATUS;
 }
@@ -1927,7 +1927,7 @@ extern "system" {
     pub fn ZwPrivilegeCheck(
         ClientToken: HANDLE,
         RequiredPrivileges: *mut PRIVILEGE_SET,
-        Result: *mut BOOLEAN,
+        Result: *mut bool,
     ) -> NTSTATUS;
 }
 
@@ -1938,7 +1938,7 @@ extern "system" {
         ServiceName: *mut UNICODE_STRING,
         ClientToken: HANDLE,
         Privileges: *mut PRIVILEGE_SET,
-        AccessGranted: BOOLEAN,
+        AccessGranted: bool,
     ) -> NTSTATUS;
 }
 
@@ -1950,7 +1950,7 @@ extern "system" {
         ClientToken: HANDLE,
         DesiredAccess: u32,
         Privileges: *mut PRIVILEGE_SET,
-        AccessGranted: BOOLEAN,
+        AccessGranted: bool,
     ) -> NTSTATUS;
 }
 
@@ -2017,7 +2017,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn ZwQueryDefaultLocale(UserProfile: BOOLEAN, DefaultLocaleId: *mut u32) -> NTSTATUS;
+    pub fn ZwQueryDefaultLocale(UserProfile: bool, DefaultLocaleId: *mut u32) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2031,8 +2031,8 @@ extern "system" {
         DirectoryHandle: HANDLE,
         Buffer: *mut std::ffi::c_void,
         Length: u32,
-        ReturnSingleEntry: BOOLEAN,
-        RestartScan: BOOLEAN,
+        ReturnSingleEntry: bool,
+        RestartScan: bool,
         Context: *mut u32,
         ReturnLength: *mut u32,
     ) -> NTSTATUS;
@@ -2365,7 +2365,7 @@ extern "system" {
     pub fn ZwRaiseException(
         ExceptionRecord: *mut EXCEPTION_RECORD,
         ContextRecord: *mut CONTEXT,
-        FirstChance: BOOLEAN,
+        FirstChance: bool,
     ) -> NTSTATUS;
 }
 
@@ -2445,7 +2445,7 @@ extern "system" {
     pub fn ZwReleaseKeyedEvent(
         KeyedEventHandle: HANDLE,
         KeyValue: *mut std::ffi::c_void,
-        Alertable: BOOLEAN,
+        Alertable: bool,
         Timeout: *mut i64,
     ) -> NTSTATUS;
 }
@@ -2488,7 +2488,7 @@ extern "system" {
         Count: u32,
         NumEntriesRemoved: *mut u32,
         Timeout: *mut i64,
-        Alertable: BOOLEAN,
+        Alertable: bool,
     ) -> NTSTATUS;
 }
 
@@ -2659,7 +2659,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn ZwSetDebugFilterState(ComponentId: u32, Level: u32, State: BOOLEAN) -> NTSTATUS;
+    pub fn ZwSetDebugFilterState(ComponentId: u32, Level: u32, State: bool) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2669,7 +2669,7 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn ZwSetDefaultLocale(UserProfile: BOOLEAN, DefaultLocaleId: u32) -> NTSTATUS;
+    pub fn ZwSetDefaultLocale(UserProfile: bool, DefaultLocaleId: u32) -> NTSTATUS;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2877,7 +2877,7 @@ extern "system" {
 extern "system" {
     pub fn ZwSetTimerResolution(
         DesiredTime: u32,
-        SetResolution: BOOLEAN,
+        SetResolution: bool,
         ActualTime: *mut u32,
     ) -> NTSTATUS;
 }
@@ -2910,7 +2910,7 @@ extern "system" {
     pub fn ZwSignalAndWaitForSingleObject(
         SignalHandle: HANDLE,
         WaitHandle: HANDLE,
-        Alertable: BOOLEAN,
+        Alertable: bool,
         Timeout: *mut i64,
     ) -> NTSTATUS;
 }
@@ -2961,7 +2961,7 @@ extern "system" {
 extern "system" {
     pub fn ZwTerminateEnclave(
         BaseAddress: *mut std::ffi::c_void,
-        WaitForThread: BOOLEAN,
+        WaitForThread: bool,
     ) -> NTSTATUS;
 }
 
@@ -3093,7 +3093,7 @@ extern "system" {
 extern "system" {
     pub fn ZwWaitForDebugEvent(
         DebugObjectHandle: HANDLE,
-        Alertable: BOOLEAN,
+        Alertable: bool,
         Timeout: *mut i64,
         WaitStateChange: *mut DBGUI_WAIT_STATE_CHANGE,
     ) -> NTSTATUS;
@@ -3104,7 +3104,7 @@ extern "system" {
     pub fn ZwWaitForKeyedEvent(
         KeyedEventHandle: HANDLE,
         KeyValue: *mut std::ffi::c_void,
-        Alertable: BOOLEAN,
+        Alertable: bool,
         Timeout: *mut i64,
     ) -> NTSTATUS;
 }
@@ -3115,7 +3115,7 @@ extern "system" {
         Count: u32,
         Handles: *mut HANDLE,
         WaitType: WAIT_TYPE,
-        Alertable: BOOLEAN,
+        Alertable: bool,
         Timeout: *mut i64,
     ) -> NTSTATUS;
 }
@@ -3126,7 +3126,7 @@ extern "system" {
         Count: u32,
         Handles: *mut i32,
         WaitType: WAIT_TYPE,
-        Alertable: BOOLEAN,
+        Alertable: bool,
         Timeout: *mut i64,
     ) -> NTSTATUS;
 }

--- a/src/phnt_ntdef.rs
+++ b/src/phnt_ntdef.rs
@@ -1,5 +1,3 @@
-use windows::Win32::Foundation::BOOLEAN;
-
 pub const NT_FACILITY_MASK: u32 = 4095;
 pub const NT_FACILITY_SHIFT: u32 = 16;
 pub const OBJ_PROTECT_CLOSE: u32 = 1;
@@ -102,4 +100,4 @@ pub type PENCLAVE_ROUTINE =
     Option<unsafe extern "system" fn(lpThreadParameter: *mut std::ffi::c_void) -> u32>;
 
 pub type WAITORTIMERCALLBACKFUNC =
-    Option<unsafe extern "system" fn(_: *mut std::ffi::c_void, _: BOOLEAN)>;
+    Option<unsafe extern "system" fn(_: *mut std::ffi::c_void, _: bool)>;

--- a/src/winsta.rs
+++ b/src/winsta.rs
@@ -1,7 +1,7 @@
 use windows::{
     core::PWSTR,
     Win32::{
-        Foundation::{BOOLEAN, FILETIME, HANDLE, HWND, UNICODE_STRING},
+        Foundation::{FILETIME, HANDLE, HWND, UNICODE_STRING},
         Security::PSID,
     },
 };
@@ -1261,7 +1261,7 @@ pub struct NASICONFIG {
     pub PassWord: NASIPASSWORD,
     pub SessionName: NASISESIONNAME,
     pub FileServer: NASIFILESERVER,
-    pub GlobalSession: BOOLEAN,
+    pub GlobalSession: bool,
 }
 
 impl Default for NASICONFIG {
@@ -1945,7 +1945,7 @@ pub type PCLIENTDATANAME = *mut i8;
 #[repr(C)]
 pub struct WINSTATIONCLIENTDATA {
     pub DataName: CLIENTDATANAME,
-    pub fUnicodeData: BOOLEAN,
+    pub fUnicodeData: bool,
 }
 
 impl Default for WINSTATIONCLIENTDATA {
@@ -2351,7 +2351,7 @@ impl std::fmt::Debug for TS_ALL_PROCESSES_INFO {
 #[repr(C)]
 pub struct TS_COUNTER_HEADER {
     pub dwCounterID: u32,
-    pub bResult: BOOLEAN,
+    pub bResult: bool,
 }
 
 impl Default for TS_COUNTER_HEADER {
@@ -2387,7 +2387,7 @@ impl std::fmt::Debug for TS_COUNTER {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn WinStationFreeMemory(Buffer: *mut std::ffi::c_void) -> BOOLEAN;
+    pub fn WinStationFreeMemory(Buffer: *mut std::ffi::c_void) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2397,12 +2397,12 @@ extern "system" {
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn WinStationCloseServer(ServerHandle: HANDLE) -> BOOLEAN;
+    pub fn WinStationCloseServer(ServerHandle: HANDLE) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn WinStationServerPing(ServerHandle: HANDLE) -> BOOLEAN;
+    pub fn WinStationServerPing(ServerHandle: HANDLE) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2411,12 +2411,12 @@ extern "system" {
         ServerHandle: HANDLE,
         Count: u32,
         Counters: *mut TS_COUNTER,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn WinStationShutdownSystem(ServerHandle: HANDLE, ShutdownFlags: u32) -> BOOLEAN;
+    pub fn WinStationShutdownSystem(ServerHandle: HANDLE, ShutdownFlags: u32) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2425,7 +2425,7 @@ extern "system" {
         ServerHandle: HANDLE,
         EventMask: u32,
         EventFlags: *mut u32,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2434,7 +2434,7 @@ extern "system" {
         ServerHandle: HANDLE,
         WindowHandle: HWND,
         Flags: u32,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2442,7 +2442,7 @@ extern "system" {
     pub fn WinStationUnRegisterConsoleNotification(
         ServerHandle: HANDLE,
         WindowHandle: HWND,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2451,7 +2451,7 @@ extern "system" {
         ServerHandle: HANDLE,
         SessionIds: *mut *mut SESSIONIDW,
         Count: *mut u32,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2463,7 +2463,7 @@ extern "system" {
         pWinStationInformation: *mut std::ffi::c_void,
         WinStationInformationLength: u32,
         pReturnLength: *mut u32,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2474,7 +2474,7 @@ extern "system" {
         WinStationInformationClass: WINSTATIONINFOCLASS,
         pWinStationInformation: *mut std::ffi::c_void,
         WinStationInformationLength: u32,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2483,7 +2483,7 @@ extern "system" {
         ServerHandle: HANDLE,
         SessionId: u32,
         pWinStationName: PWSTR,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2492,7 +2492,7 @@ extern "system" {
         ServerHandle: HANDLE,
         pWinStationName: PWSTR,
         SessionId: *mut u32,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2507,8 +2507,8 @@ extern "system" {
         Style: u32,
         Timeout: u32,
         Response: *mut u32,
-        DoNotWait: BOOLEAN,
-    ) -> BOOLEAN;
+        DoNotWait: bool,
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2518,18 +2518,18 @@ extern "system" {
         SessionId: u32,
         TargetSessionId: u32,
         pPassword: PWSTR,
-        bWait: BOOLEAN,
-    ) -> BOOLEAN;
+        bWait: bool,
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn WinStationDisconnect(ServerHandle: HANDLE, SessionId: u32, bWait: BOOLEAN) -> BOOLEAN;
+    pub fn WinStationDisconnect(ServerHandle: HANDLE, SessionId: u32, bWait: bool) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn WinStationReset(ServerHandle: HANDLE, SessionId: u32, bWait: BOOLEAN) -> BOOLEAN;
+    pub fn WinStationReset(ServerHandle: HANDLE, SessionId: u32, bWait: bool) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2540,12 +2540,12 @@ extern "system" {
         TargetSessionId: u32,
         HotKeyVk: u8,
         HotkeyModifiers: u16,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn WinStationShadowStop(ServerHandle: HANDLE, SessionId: u32, bWait: BOOLEAN) -> BOOLEAN;
+    pub fn WinStationShadowStop(ServerHandle: HANDLE, SessionId: u32, bWait: bool) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2553,7 +2553,7 @@ extern "system" {
     pub fn WinStationEnumerateProcesses(
         ServerHandle: HANDLE,
         Processes: *mut *mut std::ffi::c_void,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2563,7 +2563,7 @@ extern "system" {
         Level: u32,
         NumberOfProcesses: *mut u32,
         Processes: *mut *mut TS_ALL_PROCESSES_INFO,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2572,7 +2572,7 @@ extern "system" {
         Level: u32,
         Processes: *mut TS_ALL_PROCESSES_INFO,
         NumberOfProcesses: u32,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2581,7 +2581,7 @@ extern "system" {
         ServerHandle: HANDLE,
         ProcessId: u32,
         ExitCode: u32,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
@@ -2592,20 +2592,20 @@ extern "system" {
         ProcessStartTime: FILETIME,
         pProcessUserSid: *mut std::ffi::c_void,
         dwSidSize: *mut u32,
-    ) -> BOOLEAN;
+    ) -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn WinStationSwitchToServicesSession() -> BOOLEAN;
+    pub fn WinStationSwitchToServicesSession() -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn WinStationRevertFromServicesSession() -> BOOLEAN;
+    pub fn WinStationRevertFromServicesSession() -> bool;
 }
 
 #[link(name = "ntdll.dll", kind = "raw-dylib", modifiers = "+verbatim")]
 extern "system" {
-    pub fn _WinStationWaitForConnect() -> BOOLEAN;
+    pub fn _WinStationWaitForConnect() -> bool;
 }


### PR DESCRIPTION
Bump dependency of windows to 0.62.2
Correctly link ntbcd functions with bcd.dll